### PR TITLE
Initial PR of Resource Aggregator

### DIFF
--- a/resource-management/pkg/common-lib/interfaces/distributor/interfaces.go
+++ b/resource-management/pkg/common-lib/interfaces/distributor/interfaces.go
@@ -8,7 +8,7 @@ import (
 // TODO:
 //     Coordinate with Distributor with the interfaces defined here.
 //     Distributor will need to make a minor code changes to switch to the new place
-type Interface interface {
+type InterfacesOfDistributor interface {
 	RegisterClient(requestedHostNum int) (string, bool, error)
 	ListNodesForClient(clientId string) ([]*types.Node, types.ResourceVersionMap, error)
 	Watch(clientId string, rvs types.ResourceVersionMap, watchChan chan *event.NodeEvent, stopCh chan struct{}) error


### PR DESCRIPTION
This PR does two things:
1. Create Resource Aggregator package
    * Initial new aggregator
    * Loop to get resources from resource region managers and send to resource distributor
    * Four methods used by aggregator
       - createClient
       - initPullOrSubsequentPull
       - postCRV

2. Create interfaces/distributor/interfaces.go under directory common-lib to call ProcessEvents() from distributor