### PR TITLE
Change the package name of distributor interface to 'commonlib_distributor' from 'distributor'

### DIFF
--- a/resource-management/pkg/common-lib/interfaces/distributor/interfaces.go
+++ b/resource-management/pkg/common-lib/interfaces/distributor/interfaces.go
@@ -1,4 +1,4 @@
-package distributor
+package commonlib_distributor
 
 import (
 	"global-resource-service/resource-management/pkg/common-lib/types"


### PR DESCRIPTION
This PR is to simply change the package name of distributor interface to 'commonlib_distributor' from 'distributor' based on teammate's feedback.