### PR TITLE
Workaround for marshalling map with composite key

### DIFF
--- a/resource-management/pkg/common-lib/types/compositeresourceversion_test.go
+++ b/resource-management/pkg/common-lib/types/compositeresourceversion_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"global-resource-service/resource-management/pkg/common-lib/types/location"
+	"testing"
+)
+
+func TestResourceVersionMap_Marshall_UnMarshall(t *testing.T) {
+	rvs := make(ResourceVersionMap)
+	loc := location.NewLocation(location.Beijing, location.ResourcePartition1)
+	rvs[*loc] = 100
+
+	// marshall
+	b, err := json.Marshal(rvs)
+	assert.Nil(t, err)
+	assert.NotNil(t, b)
+
+	// unmarshall
+	var newRVMap ResourceVersionMap
+	err = json.Unmarshal(b, &newRVMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, newRVMap)
+	assert.Equal(t, 1, len(newRVMap))
+	assert.Equal(t, uint64(100), newRVMap[*loc])
+}

--- a/resource-management/pkg/common-lib/types/location/location.go
+++ b/resource-management/pkg/common-lib/types/location/location.go
@@ -1,6 +1,9 @@
 package location
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 const RingRange = float64(360)
 
@@ -262,4 +265,14 @@ func (loc *Location) Equal(locToCompare Location) bool {
 
 func (loc *Location) String() string {
 	return fmt.Sprintf("[Region %s, ResoucePartition %s]", loc.region, loc.partition)
+}
+
+func (loc Location) MarshalText() (text []byte, err error) {
+	type l Location
+	return json.Marshal(l(loc))
+}
+
+func (loc *Location) UnmarshalText(text []byte) error {
+	type l Location
+	return json.Unmarshal(text, (*l)(loc))
 }


### PR DESCRIPTION
Thanks for Carl to find json marshalling limitation for map using composite key. Thanks for Carl and Yunwen for sharing solution.

[https:/
/go.dev/play/p/4BgZn4Y37Ww
](https://stackoverflow.com/questions/55335296/problem-with-marshal-unmarshal-when-key-of-map-is-a-struct)