### PR TITLE
Add more test cases to ensure PersistNodeStoreStatus and PersistVirtualNodesAssignments both work

### DIFF
--- a/resource-management/pkg/store/redis/redis.go
+++ b/resource-management/pkg/store/redis/redis.go
@@ -37,7 +37,6 @@ func NewRedisClient() *Goredis {
 // To Test Persist Simple String
 //
 func (gr *Goredis) setString(myKey, myValue string) bool {
-
 	if len(myKey) == 0 || len(myValue) == 0 {
 		klog.Errorf("The Key or Value is blank")
 		return false
@@ -56,7 +55,6 @@ func (gr *Goredis) setString(myKey, myValue string) bool {
 // To Test Get Simple String
 //
 func (gr *Goredis) getString(myKey string) string {
-
 	var myValue string
 
 	if len(myKey) == 0 {
@@ -86,7 +84,6 @@ func (gr *Goredis) getString(myKey string) string {
 // TODO: Error handling for loop persistence failure in the middle
 //
 func (gr *Goredis) PersistNodes(logicalNodes []*types.LogicalNode) bool {
-
 	if logicalNodes == nil {
 		klog.Errorf("The array of Logical Nodes is nil")
 		return false
@@ -115,7 +112,6 @@ func (gr *Goredis) PersistNodes(logicalNodes []*types.LogicalNode) bool {
 // Use Redis data type - String to store Node Store Status
 //
 func (gr *Goredis) PersistNodeStoreStatus(nodeStoreStatus *store.NodeStoreStatus) bool {
-
 	nodeStoreStatusBytes, err := json.Marshal(nodeStoreStatus)
 
 	if err != nil {
@@ -136,7 +132,6 @@ func (gr *Goredis) PersistNodeStoreStatus(nodeStoreStatus *store.NodeStoreStatus
 // Use Redis data type - String to store Virtual Node Assignment
 //
 func (gr *Goredis) PersistVirtualNodesAssignments(virtualNodeAssignment *store.VirtualNodeAssignment) bool {
-
 	virtualNodeAssignmentBytes, err := json.Marshal(virtualNodeAssignment)
 
 	if err != nil {
@@ -159,7 +154,6 @@ func (gr *Goredis) PersistVirtualNodesAssignments(virtualNodeAssignment *store.V
 // Note: Need re-visit these codes to see whether using function pointer is much better
 //
 func (gr *Goredis) GetNodes() []*types.LogicalNode {
-
 	keys := gr.client.Keys(gr.ctx, types.PreserveNode_KeyPrefix+"*").Val()
 
 	logicalNodes := make([]*types.LogicalNode, len(keys))
@@ -193,7 +187,6 @@ func (gr *Goredis) GetNodes() []*types.LogicalNode {
 // Get Node Store Status
 //
 func (gr *Goredis) GetNodeStoreStatus() *store.NodeStoreStatus {
-
 	var nodeStoreStatus *store.NodeStoreStatus
 
 	value, err := gr.client.Get(gr.ctx, nodeStoreStatus.GetKey()).Bytes()
@@ -218,7 +211,6 @@ func (gr *Goredis) GetNodeStoreStatus() *store.NodeStoreStatus {
 // Get Virtual Nodes Assignments
 //
 func (gr *Goredis) GetVirtualNodesAssignments() *store.VirtualNodeAssignment {
-
 	var virtualNodeAssignment *store.VirtualNodeAssignment
 
 	value, err := gr.client.Get(gr.ctx, virtualNodeAssignment.GetKey()).Bytes()

--- a/resource-management/pkg/store/redis/redis_test.go
+++ b/resource-management/pkg/store/redis/redis_test.go
@@ -1,11 +1,12 @@
 package redis
 
 import (
+	"reflect"
+	"testing"
+
 	"global-resource-service/resource-management/pkg/common-lib/interfaces/store"
 	"global-resource-service/resource-management/pkg/common-lib/types"
 	"global-resource-service/resource-management/pkg/common-lib/types/location"
-	"reflect"
-	"testing"
 )
 
 var GR *Goredis


### PR DESCRIPTION
This PR is to add the test cases to ensure two methods of PersistNodeStoreStatus and PersistVirtualNodesAssignments , which write the data to Redis Store, both work after PR26 "Workaround for marshalling map with composite key" is merged into main branch.