### PR TITLE
use local serialization lib,  part-1

### DIFF
--- a/resource-management/go.mod
+++ b/resource-management/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.7.1

--- a/resource-management/pkg/common-lib/framer/framer.go
+++ b/resource-management/pkg/common-lib/framer/framer.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Copyright 2022 Authors of Arktos - file modified.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package framer implements simple frame decoding techniques for an io.ReadCloser
+package framer
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"io"
+)
+
+type lengthDelimitedFrameWriter struct {
+	w io.Writer
+	h [4]byte
+}
+
+func NewLengthDelimitedFrameWriter(w io.Writer) io.Writer {
+	return &lengthDelimitedFrameWriter{w: w}
+}
+
+// Write writes a single frame to the nested writer, prepending it with the length in
+// in bytes of data (as a 4 byte, bigendian uint32).
+func (w *lengthDelimitedFrameWriter) Write(data []byte) (int, error) {
+	binary.BigEndian.PutUint32(w.h[:], uint32(len(data)))
+	n, err := w.w.Write(w.h[:])
+	if err != nil {
+		return 0, err
+	}
+	if n != len(w.h) {
+		return 0, io.ErrShortWrite
+	}
+	return w.w.Write(data)
+}
+
+type lengthDelimitedFrameReader struct {
+	r         io.ReadCloser
+	remaining int
+}
+
+// NewLengthDelimitedFrameReader returns an io.Reader that will decode length-prefixed
+// frames off of a stream.
+//
+// The protocol is:
+//
+//   stream: message ...
+//   message: prefix body
+//   prefix: 4 byte uint32 in BigEndian order, denotes length of body
+//   body: bytes (0..prefix)
+//
+// If the buffer passed to Read is not long enough to contain an entire frame, io.ErrShortRead
+// will be returned along with the number of bytes read.
+func NewLengthDelimitedFrameReader(r io.ReadCloser) io.ReadCloser {
+	return &lengthDelimitedFrameReader{r: r}
+}
+
+// Read attempts to read an entire frame into data. If that is not possible, io.ErrShortBuffer
+// is returned and subsequent calls will attempt to read the last frame. A frame is complete when
+// err is nil.
+func (r *lengthDelimitedFrameReader) Read(data []byte) (int, error) {
+	if r.remaining <= 0 {
+		header := [4]byte{}
+		n, err := io.ReadAtLeast(r.r, header[:4], 4)
+		if err != nil {
+			return 0, err
+		}
+		if n != 4 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		frameLength := int(binary.BigEndian.Uint32(header[:]))
+		r.remaining = frameLength
+	}
+
+	expect := r.remaining
+	max := expect
+	if max > len(data) {
+		max = len(data)
+	}
+	n, err := io.ReadAtLeast(r.r, data[:max], int(max))
+	r.remaining -= n
+	if err == io.ErrShortBuffer || r.remaining > 0 {
+		return n, io.ErrShortBuffer
+	}
+	if err != nil {
+		return n, err
+	}
+	if n != expect {
+		return n, io.ErrUnexpectedEOF
+	}
+
+	return n, nil
+}
+
+func (r *lengthDelimitedFrameReader) Close() error {
+	return r.r.Close()
+}
+
+type jsonFrameReader struct {
+	r         io.ReadCloser
+	decoder   *json.Decoder
+	remaining []byte
+}
+
+// NewJSONFramedReader returns an io.Reader that will decode individual JSON objects off
+// of a wire.
+//
+// The boundaries between each frame are valid JSON objects. A JSON parsing error will terminate
+// the read.
+func NewJSONFramedReader(r io.ReadCloser) io.ReadCloser {
+	return &jsonFrameReader{
+		r:       r,
+		decoder: json.NewDecoder(r),
+	}
+}
+
+// ReadFrame decodes the next JSON object in the stream, or returns an error. The returned
+// byte slice will be modified the next time ReadFrame is invoked and should not be altered.
+func (r *jsonFrameReader) Read(data []byte) (int, error) {
+	// Return whatever remaining data exists from an in progress frame
+	if n := len(r.remaining); n > 0 {
+		if n <= len(data) {
+			//nolint:staticcheck // SA4006,SA4010 underlying array of data is modified here.
+			data = append(data[0:0], r.remaining...)
+			r.remaining = nil
+			return n, nil
+		}
+
+		n = len(data)
+		//nolint:staticcheck // SA4006,SA4010 underlying array of data is modified here.
+		data = append(data[0:0], r.remaining[:n]...)
+		r.remaining = r.remaining[n:]
+		return n, io.ErrShortBuffer
+	}
+
+	// RawMessage#Unmarshal appends to data - we reset the slice down to 0 and will either see
+	// data written to data, or be larger than data and a different array.
+	n := len(data)
+	m := json.RawMessage(data[:0])
+	if err := r.decoder.Decode(&m); err != nil {
+		return 0, err
+	}
+
+	// If capacity of data is less than length of the message, decoder will allocate a new slice
+	// and set m to it, which means we need to copy the partial result back into data and preserve
+	// the remaining result for subsequent reads.
+	if len(m) > n {
+		//nolint:staticcheck // SA4006,SA4010 underlying array of data is modified here.
+		data = append(data[0:0], m[:n]...)
+		r.remaining = m[n:]
+		return n, io.ErrShortBuffer
+	}
+	return len(m), nil
+}
+
+func (r *jsonFrameReader) Close() error {
+	return r.r.Close()
+}

--- a/resource-management/pkg/common-lib/framer/framer_test.go
+++ b/resource-management/pkg/common-lib/framer/framer_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Copyright 2022 Authors of Arktos - file modified.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framer
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+func TestRead(t *testing.T) {
+	data := []byte{
+		0x00, 0x00, 0x00, 0x04,
+		0x01, 0x02, 0x03, 0x04,
+		0x00, 0x00, 0x00, 0x03,
+		0x05, 0x06, 0x07,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		0x08,
+	}
+	b := bytes.NewBuffer(data)
+	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	buf := make([]byte, 1)
+	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x01}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x02}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	// read the remaining frame
+	buf = make([]byte, 2)
+	if n, err := r.Read(buf); err != nil && n != 2 && bytes.Equal(buf, []byte{0x03, 0x04}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	// read with buffer equal to frame
+	buf = make([]byte, 3)
+	if n, err := r.Read(buf); err != nil && n != 3 && bytes.Equal(buf, []byte{0x05, 0x06, 0x07}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	// read empty frame
+	buf = make([]byte, 3)
+	if n, err := r.Read(buf); err != nil && n != 0 && bytes.Equal(buf, []byte{}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	// read with larger buffer than frame
+	buf = make([]byte, 3)
+	if n, err := r.Read(buf); err != nil && n != 1 && bytes.Equal(buf, []byte{0x08}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	// read EOF
+	if n, err := r.Read(buf); err != io.EOF && n != 0 {
+		t.Fatalf("unexpected: %v %d", err, n)
+	}
+}
+
+func TestReadLarge(t *testing.T) {
+	data := []byte{
+		0x00, 0x00, 0x00, 0x04,
+		0x01, 0x02, 0x03, 0x04,
+		0x00, 0x00, 0x00, 0x03,
+		0x05, 0x06, 0x07,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		0x08,
+	}
+	b := bytes.NewBuffer(data)
+	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	buf := make([]byte, 40)
+	if n, err := r.Read(buf); err != nil && n != 4 && bytes.Equal(buf, []byte{0x01, 0x02, 0x03, 0x04}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != nil && n != 3 && bytes.Equal(buf, []byte{0x05, 0x06, 0x7}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != nil && n != 0 && bytes.Equal(buf, []byte{}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != nil && n != 1 && bytes.Equal(buf, []byte{0x08}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	// read EOF
+	if n, err := r.Read(buf); err != io.EOF && n != 0 {
+		t.Fatalf("unexpected: %v %d", err, n)
+	}
+}
+func TestReadInvalidFrame(t *testing.T) {
+	data := []byte{
+		0x00, 0x00, 0x00, 0x04,
+		0x01, 0x02,
+	}
+	b := bytes.NewBuffer(data)
+	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	buf := make([]byte, 1)
+	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x01}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	// read the remaining frame
+	buf = make([]byte, 3)
+	if n, err := r.Read(buf); err != io.ErrUnexpectedEOF && n != 1 && bytes.Equal(buf, []byte{0x02}) {
+		t.Fatalf("unexpected: %v %d %v", err, n, buf)
+	}
+	// read EOF
+	if n, err := r.Read(buf); err != io.EOF && n != 0 {
+		t.Fatalf("unexpected: %v %d", err, n)
+	}
+}
+
+func TestJSONFrameReader(t *testing.T) {
+	b := bytes.NewBufferString("{\"test\":true}\n1\n[\"a\"]")
+	r := NewJSONFramedReader(ioutil.NopCloser(b))
+	buf := make([]byte, 20)
+	if n, err := r.Read(buf); err != nil || n != 13 || string(buf[:n]) != `{"test":true}` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != nil || n != 1 || string(buf[:n]) != `1` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != nil || n != 5 || string(buf[:n]) != `["a"]` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != io.EOF || n != 0 {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+}
+
+func TestJSONFrameReaderShortBuffer(t *testing.T) {
+	b := bytes.NewBufferString("{\"test\":true}\n1\n[\"a\"]")
+	r := NewJSONFramedReader(ioutil.NopCloser(b))
+	buf := make([]byte, 3)
+
+	if n, err := r.Read(buf); err != io.ErrShortBuffer || n != 3 || string(buf[:n]) != `{"t` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != io.ErrShortBuffer || n != 3 || string(buf[:n]) != `est` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != io.ErrShortBuffer || n != 3 || string(buf[:n]) != `":t` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != io.ErrShortBuffer || n != 3 || string(buf[:n]) != `rue` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != nil || n != 1 || string(buf[:n]) != `}` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+
+	if n, err := r.Read(buf); err != nil || n != 1 || string(buf[:n]) != `1` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+
+	if n, err := r.Read(buf); err != io.ErrShortBuffer || n != 3 || string(buf[:n]) != `["a` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+	if n, err := r.Read(buf); err != nil || n != 2 || string(buf[:n]) != `"]` {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+
+	if n, err := r.Read(buf); err != io.EOF || n != 0 {
+		t.Fatalf("unexpected: %v %d %q", err, n, buf)
+	}
+}

--- a/resource-management/pkg/common-lib/serializer/interfaces.go
+++ b/resource-management/pkg/common-lib/serializer/interfaces.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+Copyright 2022 Authors of Arktos - file modified.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"io"
+)
+
+// MemoryAllocator is responsible for allocating memory.
+// By encapsulating memory allocation into its own interface, we can reuse the memory
+// across many operations in places we know it can significantly improve the performance.
+type MemoryAllocator interface {
+	// Allocate reserves memory for n bytes.
+	// Note that implementations of this method are not required to zero the returned array.
+	// It is the caller's responsibility to clean the memory if needed.
+	Allocate(n uint64) []byte
+}
+
+// SimpleAllocator a wrapper around make([]byte)
+// conforms to the MemoryAllocator interface
+type SimpleAllocator struct{}
+
+var _ MemoryAllocator = &SimpleAllocator{}
+
+func (sa *SimpleAllocator) Allocate(n uint64) []byte {
+	return make([]byte, n, n)
+}
+
+type ObjectTyper string
+
+// Identifier represents an identifier.
+// Identitier of two different objects should be equal if and only if for every
+// input the output they produce is exactly the same.
+type Identifier string
+
+// Encoder writes objects to a serialized form
+type Encoder interface {
+	Encode(interface{}, io.Writer) error
+	Identifier() Identifier
+}
+
+//// MemoryAllocator is responsible for allocating memory.
+//// By encapsulating memory allocation into its own interface, we can reuse the memory
+//// across many operations in places we know it can significantly improve the performance.
+//type MemoryAllocator interface {
+//	// Allocate reserves memory for n bytes.
+//	// Note that implementations of this method are not required to zero the returned array.
+//	// It is the caller's responsibility to clean the memory if needed.
+//	Allocate(n uint64) []byte
+//}
+//
+//// EncoderWithAllocator  serializes objects in a way that allows callers to manage any additional memory allocations.
+//type EncoderWithAllocator interface {
+//	Encoder
+//	// EncodeWithAllocator writes an object to a stream as Encode does.
+//	// In addition, it allows for providing a memory allocator for efficient memory usage during object serialization
+//	EncodeWithAllocator(obj interface{}, w io.Writer, memAlloc MemoryAllocator) error
+//}
+
+// Decoder attempts to load an object from data.
+type Decoder interface {
+	Decode([]byte, interface{}) (interface{}, error)
+}
+
+// Serializer is the core interface for transforming objects into a serialized format and back.
+// Implementations may choose to perform conversion of the object, but no assumptions should be made.
+type Serializer interface {
+	Encoder
+	Decoder
+}
+
+// Codec is a Serializer that deals with the details of versioning objects. It offers the same
+// interface as Serializer, so this is a marker to consumers that care about the version of the objects
+// they receive.
+// type Codec Serializer
+
+//// ParameterCodec defines methods for serializing and deserializing API objects to url.Values and
+//// performing any necessary conversion. Unlike the normal Codec, query parameters are not self describing
+//// and the desired version must be specified.
+//type ParameterCodec interface {
+//	// DecodeParameters takes the given url.Values in the specified group version and decodes them
+//	// into the provided object, or returns an error.
+//	DecodeParameters(parameters url.Values, into interface{}) error
+//	// EncodeParameters encodes the provided object as query parameters or returns an error.
+//	EncodeParameters(obj interface{}) (url.Values, error)
+//}
+
+// Framer is a factory for creating readers and writers that obey a particular framing pattern.
+type Framer interface {
+	NewFrameReader(r io.ReadCloser) io.ReadCloser
+	NewFrameWriter(w io.Writer) io.Writer
+}
+
+//// SerializerInfo contains information about a specific serialization format
+//type SerializerInfo struct {
+//	// MediaType is the value that represents this serializer over the wire.
+//	MediaType string
+//	// MediaTypeType is the first part of the MediaType ("application" in "application/json").
+//	MediaTypeType string
+//	// MediaTypeSubType is the second part of the MediaType ("json" in "application/json").
+//	MediaTypeSubType string
+//	// EncodesAsText indicates this serializer can be encoded to UTF-8 safely.
+//	EncodesAsText bool
+//	// Serializer is the individual object serializer for this media type.
+//	Serializer Serializer
+//	// PrettySerializer, if set, can serialize this object in a form biased towards
+//	// readability.
+//	PrettySerializer Serializer
+//	// StrictSerializer, if set, deserializes this object strictly,
+//	// erring on unknown fields.
+//	StrictSerializer Serializer
+//	// StreamSerializer, if set, describes the streaming serialization format
+//	// for this media type.
+//	StreamSerializer *StreamSerializerInfo
+//}
+//
+// StreamSerializerInfo contains information about a specific stream serialization format
+//type StreamSerializerInfo struct {
+//	// EncodesAsText indicates this serializer can be encoded to UTF-8 safely.
+//	EncodesAsText bool
+//	// Serializer is the top level object serializer for this type when streaming
+//	Serializer
+//	// Framer is the factory for retrieving streams that separate objects on the wire
+//	Framer
+//}
+
+//// NegotiatedSerializer is an interface used for obtaining encoders, decoders, and serializers
+//// for multiple supported media types. This would commonly be accepted by a server component
+//// that performs HTTP content negotiation to accept multiple formats.
+//type NegotiatedSerializer interface {
+//	// SupportedMediaTypes is the media types supported for reading and writing single objects.
+//	SupportedMediaTypes() []SerializerInfo
+//
+//	// EncoderForVersion returns an encoder that ensures objects being written to the provided
+//	// serializer are in the provided group version.
+//	EncoderForVersion(serializer Encoder) Encoder
+//	// DecoderToVersion returns a decoder that ensures objects being read by the provided
+//	// serializer are in the provided group version by default.
+//	DecoderToVersion(serializer Decoder) Decoder
+//}
+
+//// ClientNegotiator handles turning an HTTP content type into the appropriate encoder.
+//// Use NewClientNegotiator or NewVersionedClientNegotiator to create this interface from
+//// a NegotiatedSerializer.
+//type ClientNegotiator interface {
+//	// Encoder returns the appropriate encoder for the provided contentType (e.g. application/json)
+//	// and any optional mediaType parameters (e.g. pretty=1), or an error. If no serializer is found
+//	// a NegotiateError will be returned. The current client implementations consider params to be
+//	// optional modifiers to the contentType and will ignore unrecognized parameters.
+//	Encoder(contentType string, params map[string]string) (Encoder, error)
+//	// Decoder returns the appropriate decoder for the provided contentType (e.g. application/json)
+//	// and any optional mediaType parameters (e.g. pretty=1), or an error. If no serializer is found
+//	// a NegotiateError will be returned. The current client implementations consider params to be
+//	// optional modifiers to the contentType and will ignore unrecognized parameters.
+//	Decoder(contentType string, params map[string]string) (Decoder, error)
+//	// StreamDecoder returns the appropriate stream decoder for the provided contentType (e.g.
+//	// application/json) and any optional mediaType parameters (e.g. pretty=1), or an error. If no
+//	// serializer is found a NegotiateError will be returned. The Serializer and Framer will always
+//	// be returned if a Decoder is returned. The current client implementations consider params to be
+//	// optional modifiers to the contentType and will ignore unrecognized parameters.
+//	StreamDecoder(contentType string, params map[string]string) (Decoder, Serializer, Framer, error)
+//}
+
+//// StorageSerializer is an interface used for obtaining encoders, decoders, and serializers
+//// that can read and write data at rest. This would commonly be used by client tools that must
+//// read files, or server side storage interfaces that persist restful objects.
+//type StorageSerializer interface {
+//	// SupportedMediaTypes are the media types supported for reading and writing objects.
+//	SupportedMediaTypes() []SerializerInfo
+//
+//	// UniversalDeserializer returns a Serializer that can read objects in multiple supported formats
+//	// by introspecting the data at rest.
+//	UniversalDeserializer() Decoder
+//
+//	// EncoderForVersion returns an encoder that ensures objects being written to the provided
+//	// serializer are in the provided group version.
+//	EncoderForVersion(serializer Encoder) Encoder
+//	// DecoderForVersion returns a decoder that ensures objects being read by the provided
+//	// serializer are in the provided group version by default.
+//	DecoderToVersion(serializer Decoder) Decoder
+//}
+
+//// for POC, simply without versioning support of the node object
+//type ObjectCreater interface {
+//	New() (out interface{}, err error)
+//}

--- a/resource-management/pkg/common-lib/serializer/json/json.go
+++ b/resource-management/pkg/common-lib/serializer/json/json.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Copyright 2022 Authors of Arktos - file modified.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"encoding/json"
+	"io"
+	"strconv"
+
+	"k8s.io/klog/v2"
+
+	"global-resource-service/resource-management/pkg/common-lib/serializer"
+)
+
+func NewSerializer(typer serializer.ObjectTyper, pretty bool) *Serializer {
+	return NewSerializerWithOptions(typer, SerializerOptions{false, false})
+}
+
+// NewSerializerWithOptions creates a JSON/YAML serializer that handles encoding versioned objects into the proper JSON/YAML
+// form. If typer is not nil, the object has the group, version, and kind fields set. Options are copied into the Serializer
+// and are immutable.
+func NewSerializerWithOptions(typer serializer.ObjectTyper, options SerializerOptions) *Serializer {
+	return &Serializer{
+		typer:      typer,
+		options:    options,
+		identifier: identifier(options),
+	}
+}
+
+// identifier computes Identifier of Encoder based on the given options.
+func identifier(options SerializerOptions) serializer.Identifier {
+	result := map[string]string{
+		"name":   "json",
+		"pretty": strconv.FormatBool(options.Pretty),
+		"strict": strconv.FormatBool(options.Strict),
+	}
+	identifier, err := json.Marshal(result)
+	if err != nil {
+		klog.Fatalf("Failed marshaling identifier for json Serializer: %v", err)
+	}
+	return serializer.Identifier(identifier)
+}
+
+type SerializerOptions struct {
+	// Pretty: configures a JSON enabled Serializer(`Yaml: false`) to produce human-readable output.
+	Pretty bool
+
+	// Strict: configures the Serializer to return strictDecodingError's when duplicate fields are present decoding JSON or YAML.
+	// Note that enabling this option is not as performant as the non-strict variant, and should not be used in fast paths.
+	Strict bool
+}
+
+// Serializer handles encoding versioned objects into the proper JSON form
+type Serializer struct {
+	options    SerializerOptions
+	typer      serializer.ObjectTyper
+	identifier serializer.Identifier
+}
+
+func (s *Serializer) Decode(data []byte, into interface{}) (interface{}, error) {
+
+	err := s.Unmarshal(data, &into)
+
+	return into, err
+}
+
+// Encode serializes the provided object to the given writer.
+func (s *Serializer) Encode(obj interface{}, w io.Writer) error {
+	return s.doEncode(obj, w)
+}
+
+func (s *Serializer) doEncode(obj interface{}, w io.Writer) error {
+	if s.options.Pretty {
+		data, err := json.MarshalIndent(obj, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(data)
+		return err
+	}
+	encoder := json.NewEncoder(w)
+	return encoder.Encode(obj)
+}
+
+// IsStrict indicates whether the serializer
+// uses strict decoding or not
+func (s *Serializer) IsStrict() bool {
+	return s.options.Strict
+}
+
+func (s *Serializer) Unmarshal(data []byte, into *interface{}) (err error) {
+	return json.Unmarshal(data, into)
+}
+
+// Identifier implements serializer.Encoder interface.
+func (s *Serializer) Identifier() serializer.Identifier {
+	return s.identifier
+}
+
+//// Framer is the default JSON framing behavior, with newlines delimiting individual objects.
+//var Framer = jsonFramer{}
+//
+//type jsonFramer struct{}
+//
+//// NewFrameWriter implements stream framing for this serializer
+//func (jsonFramer) NewFrameWriter(w io.Writer) io.Writer {
+//	// we can write JSON objects directly to the writer, because they are self-framing
+//	return w
+//}
+//
+//// NewFrameReader implements stream framing for this serializer
+//func (jsonFramer) NewFrameReader(r io.ReadCloser) io.ReadCloser {
+//	// we need to extract the JSON chunks of data to pass to Decode()
+//	return framer.NewJSONFramedReader(r)
+//}

--- a/resource-management/pkg/common-lib/serializer/protobuf/protobuf.go
+++ b/resource-management/pkg/common-lib/serializer/protobuf/protobuf.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Copyright 2022 Authors of Arktos - file modified.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protobuf
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/golang/protobuf/proto"
+	"k8s.io/klog/v2"
+
+	"global-resource-service/resource-management/pkg/common-lib/serializer"
+)
+
+type errNotMarshalable struct {
+	t reflect.Type
+}
+
+func (e errNotMarshalable) Error() string {
+	return fmt.Sprintf("object %v does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message", e.t)
+}
+
+// IsNotMarshalable checks the type of error, returns a boolean true if error is not nil and not marshalable false otherwise
+func IsNotMarshalable(err error) bool {
+	_, ok := err.(errNotMarshalable)
+	return err != nil && ok
+}
+
+// NewSerializer creates a Protobuf serializer that handles encoding versioned objects into the proper wire form. If a typer
+// is passed, the encoded object will have group, version, and kind fields set. If typer is nil, the objects will be written
+// as-is (any type info passed with the object will be used).
+func NewSerializer(typer serializer.ObjectTyper) *Serializer {
+	return &Serializer{
+		typer: typer,
+	}
+}
+
+// Serializer handles encoding versioned objects into the proper wire form
+type Serializer struct {
+	prefix []byte
+	typer  serializer.ObjectTyper
+}
+
+var _ serializer.Serializer = &Serializer{}
+
+const serializerIdentifier serializer.Identifier = "protobuf"
+
+// Decode attempts to convert the provided data into a protobuf message, extract the stored schema kind, apply the provided default
+// gvk, and then load that data into an object matching the desired schema kind or the provided into. If into is *serializer.Unknown,
+// the raw data will be extracted and no decoding will be performed. If into is not registered with the typer, then the object will
+// be straight decoded using normal protobuf unmarshalling (the MarshalTo interface). If into is provided and the original data is
+// not fully qualified with kind/version/group, the type of the into will be used to alter the returned gvk. On success or most
+// errors, the method will return the calculated schema kind.
+func (s *Serializer) Decode(data []byte, into interface{}) (interface{}, error) {
+
+	err := proto.Unmarshal(data, into.(proto.Message))
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal data")
+	}
+
+	return into, nil
+}
+
+// Encode serializes the provided object to the given writer.
+func (s *Serializer) Encode(obj interface{}, w io.Writer) error {
+	b, err := proto.Marshal(obj.(proto.Message))
+
+	if err != nil {
+		klog.Errorf("failed to marshal object, error %v", err)
+		return err
+	}
+
+	_, err = w.Write(b)
+	if err != nil {
+		klog.Errorf("failed to write response, error %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// Identifier implements serializer.Encoder interface.
+func (s *Serializer) Identifier() serializer.Identifier {
+	return serializerIdentifier
+}
+
+//// LengthDelimitedFramer is exported variable of type lengthDelimitedFramer
+//var LengthDelimitedFramer = lengthDelimitedFramer{}
+//
+//// Provides length delimited frame reader and writer methods
+//type lengthDelimitedFramer struct{}
+//
+//// NewFrameWriter implements stream framing for this serializer
+//func (lengthDelimitedFramer) NewFrameWriter(w io.Writer) io.Writer {
+//	return framer.NewLengthDelimitedFrameWriter(w)
+//}
+//
+//// NewFrameReader implements stream framing for this serializer
+//func (lengthDelimitedFramer) NewFrameReader(r io.ReadCloser) io.ReadCloser {
+//	return framer.NewLengthDelimitedFrameReader(r)
+//}

--- a/resource-management/pkg/service-api/endpoints/installer.go
+++ b/resource-management/pkg/service-api/endpoints/installer.go
@@ -207,7 +207,6 @@ func (i *Installer) serverWatch(resp http.ResponseWriter, req *http.Request, cli
 			}
 
 			if err := desiredSerializer.Encode(*record.Node, resp); err != nil {
-				//	if err := json.NewEncoder(resp).Encode(*record.Node); err != nil {
 				klog.V(3).Infof("encoding record failed. error %v", err)
 				resp.WriteHeader(http.StatusInternalServerError)
 				return
@@ -234,7 +233,6 @@ func getResourceVersionsMap(req *http.Request, s serializer.Serializer) (types.R
 	wr := apiTypes.WatchRequest{}
 
 	r, err := s.Decode(body, wr)
-	//err = json.Unmarshal(body, wr)
 	if err != nil {
 		return nil, err
 	}

--- a/resource-management/pkg/service-api/endpoints/installer_test.go
+++ b/resource-management/pkg/service-api/endpoints/installer_test.go
@@ -74,7 +74,7 @@ func TestHttpGet(t *testing.T) {
 	distributor.SetPersistHelper(fakeStorage)
 	installer := NewInstaller(distributor)
 
-	// initialize node store with 10K nodes
+	// initialize node store with 1m nodes
 	eventsAdd := generateAddNodeEvent(1000000)
 
 	klog.Infof("start process [%v] events: %v", len(eventsAdd), time.Now().String())
@@ -115,7 +115,7 @@ func TestHttpGet(t *testing.T) {
 	dec := json.NewDecoder(recorder.Body)
 
 	chunks := 0
-	expectedChunks := requestMachines / 500
+	expectedChunks := requestMachines / 500     // default chunk size is 500
 	for dec.More() {
 		err := dec.Decode(&decNodes)
 		if err != nil {


### PR DESCRIPTION
code-level reuse the serializer package from the apimachinery/serializer package.
the heavy meta data, such as multiple type, versioning conversion in the serializer package has been removed.