### PR TITLE
Aggregator and ResourceRegionManager Simulator Integration: bug fixing

### DIFF
--- a/hack/redis_install.sh
+++ b/hack/redis_install.sh
@@ -5,9 +5,9 @@
 #
 #    Running on Ubuntu 20.04: ./hack/redis_install.sh
 #                              Redis 7.0.0 is installed as default
-#    Running on Ubuntu 18.04: ./bin/bash ./hack/redis_install.sh
+#    Running on Ubuntu 18.04:  /bin/bash ./hack/redis_install.sh
 #                              Redis 7.0.0 is installed as default
-#    Running on Ubuntu 16.04: ./bin/bash ./hack/redis_install.sh
+#    Running on Ubuntu 16.04:  /bin/bash ./hack/redis_install.sh
 #                              Redis 7.0.0 is installed as default
 #
 #    Running on MacOS:  /bin/bash ./hack/redis_install.sh

--- a/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
@@ -74,7 +74,7 @@ func MakeDataUpdate() {
 // Return region node added events in BATCH LENGTH from all RPs
 // TO DO: paginate support
 //
-func GetRegionNodeAddedEvents(batchLength int) (simulatorTypes.RegionNodeEvents, uint64) {
+func GetRegionNodeAddedEvents(batchLength uint64) (simulatorTypes.RegionNodeEvents, uint64) {
 	klog.Infof("Total (%v) Added events are to be pulled", RpNum*NodesPerRP)
 	return RegionNodeEventsList, uint64(RpNum * NodesPerRP)
 

--- a/resource-management/test/resourceRegionMgrSimulator/handlers/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/handlers/regionNodeEvents.go
@@ -47,13 +47,13 @@ func (re *RegionNodeEventHandler) SimulatorHandler(rw http.ResponseWriter, r *ht
 
 	// Check CRV data received from aggregator client side
 	if r.URL.Path == InitPullPath {
-		if aggregatorClientReq.CRV != nil {
-			klog.Error("Error: CRV should nil, but right now it is not nil")
+		if len(aggregatorClientReq.CRV) != 0 {
+			klog.Error("Error: CRV should blank, but right now it is not blank")
 			return
 		}
 	} else if r.URL.Path == SubsequentPullPath || r.URL.Path == PostCRVPath {
-		if aggregatorClientReq.CRV == nil {
-			klog.Error("Error: CRVs should not nil, but right now it is nil")
+		if len(aggregatorClientReq.CRV) == 0 {
+			klog.Error("Error: CRVs should not blank, but right now it is blank")
 			return
 		}
 	} else {
@@ -77,10 +77,10 @@ func (re *RegionNodeEventHandler) SimulatorHandler(rw http.ResponseWriter, r *ht
 			nodeEvents, count = data.GetRegionNodeModifiedEventsCRV(aggregatorClientReq.CRV)
 		}
 
-		if count == 0 {
+		if len(nodeEvents) == 0 {
 			klog.Info("Pulling Region Node Events with batch is in the end")
 		} else {
-			klog.Infof("Pulling Region Node Event with final batch size (%v)", count)
+			klog.Infof("Pulling Region Node Event with final batch size (%v) for (%v) regions", count, len(nodeEvents))
 
 			response := &simulatorTypes.ResponseFromRRM{
 				RegionNodeEvents: nodeEvents,
@@ -93,6 +93,12 @@ func (re *RegionNodeEventHandler) SimulatorHandler(rw http.ResponseWriter, r *ht
 
 			if err != nil {
 				klog.Errorf("Error - Unable to marshal json : ", err)
+			}
+
+			if r.URL.Path == InitPullPath {
+				klog.Info("Handle GET all region node added events via initPull successfully")
+			} else {
+				klog.Info("Handle GET all region node modified events via SubsequentPull succesfully")
 			}
 		}
 
@@ -107,5 +113,7 @@ func (re *RegionNodeEventHandler) SimulatorHandler(rw http.ResponseWriter, r *ht
 		if err != nil {
 			klog.Errorf("Error - Unable to marshal json : ", err)
 		}
+
+		klog.Info("Handle POST CRV to discard all old region node modified events successfully")
 	}
 }

--- a/resource-management/test/resourceRegionMgrSimulator/types/types.go
+++ b/resource-management/test/resourceRegionMgrSimulator/types/types.go
@@ -23,7 +23,7 @@ type ResponseFromRRM struct {
 // The type is for pulling data with batch from RRM - Resource Region Manager
 //
 type PullDataFromRRM struct {
-	BatchLength int
+	BatchLength uint64
 	DefaultCRV  uint64
 	CRV         types.ResourceVersionMap
 }


### PR DESCRIPTION
When we do integration test of Aggregator and ResourceRegionManager Integration, first bug "Aggregator should not exit if the resource region manager is not available" has been fixed and Redis store should be started successfully.

Integration tests have been successful in local development Mac.

Currently ResourceRegionManager simulator uses 2D array to store region node events whereas Resource Aggregator uses 1D array to store mini record node events to call distributor processEvents method. Aggregator needs to convert 2D array to 1D array before calling Distributor ProcessEvents method.

By the way, without the above conversion from above 2D array to 1D array,  the code changes for "Call the ProcessEvents Per RP to unload some cost from the Distributor" have been tested in local development Mac, but performance is not good. After 20-30 minutes, aggregator complains "can not connect to localhost".

//Call ProcessEvents() and get the CRV from distributor as default success
//TODO:
//    1. Call the ProcessEvents Per RP to unload some cost from the Distributor
//       The performance tested in development Mac is not good