### PR TITLE
service bug fixes and end to end test with curl: client register and list resource

### DIFF
--- a/resource-management/cmds/service-api/app/server.go
+++ b/resource-management/cmds/service-api/app/server.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -33,29 +34,20 @@ func Run(c *Config) error {
 
 	// TODO: reuse k8s mux wrapper, pathrecorder.go for simplify this handler by each path
 	r.HandleFunc(endpoints.ListResourcePath, installer.ResourceHandler).Methods("GET")
-	r.HandleFunc(endpoints.WatchResourcePath, installer.ResourceHandler)
+	r.HandleFunc(endpoints.WatchResourcePath, installer.ResourceHandler).Methods("GET")
 	r.HandleFunc(endpoints.UpdateResourcePath, installer.ResourceHandler)
 	r.HandleFunc(endpoints.ReduceResourcePath, installer.ResourceHandler)
 
 	r.HandleFunc(endpoints.ClientAdminitrationPath, installer.ClientAdministrationHandler)
 	r.HandleFunc(endpoints.ClientAdminitrationPath+"/{clientId}", installer.ClientAdministrationHandler)
 
-	var addr string
-	var p string
-
-	if c.MasterIp == "" {
-		addr = "localhost"
-	}
-
-	if c.MasterPort == "" {
-		p = endpoints.InsecureServiceAPIPort
-	}
-
+	address := fmt.Sprintf("%s:%s", c.MasterIp, c.MasterPort)
+	klog.Infof("Serving at %s", address)
 	server := &http.Server{
 		Handler:      r,
-		Addr:         addr + p,
-		WriteTimeout: 2 * time.Second,
-		ReadTimeout:  2 * time.Second,
+		Addr:         address,
+		WriteTimeout: 120 * time.Second,
+		ReadTimeout:  120 * time.Second,
 	}
 
 	// start the service and aggregator in go routines

--- a/resource-management/cmds/service-api/service-api.go
+++ b/resource-management/cmds/service-api/service-api.go
@@ -47,7 +47,7 @@ func main() {
 		klog.Errorf("error: %v\n", err)
 	}
 
-	klog.Infof("Exiting reesource management service")
+	klog.Infof("Exiting resource management service")
 }
 
 // function to print the usage info for the resource management api server

--- a/resource-management/pkg/service-api/endpoints/constants.go
+++ b/resource-management/pkg/service-api/endpoints/constants.go
@@ -7,7 +7,7 @@ const (
 	//RegionlessResourcePath is the default api service url
 	RegionlessResourcePath = "/resource"
 	ListResourcePath       = RegionlessResourcePath + "/{clientid}"
-	WatchResourcePath      = RegionlessResourcePath + "/{clientid}?watch?{resourceVersion}"
+	WatchResourcePath      = RegionlessResourcePath + "/{clientid}"
 	UpdateResourcePath     = RegionlessResourcePath + "/{clientid}" + "/addResource"
 	ReduceResourcePath     = RegionlessResourcePath + "/{clientid}" + "/reduceResource"
 	// InsecureServiceAPIPort is the default port for Service-api when running insecure mode.

--- a/resource-management/pkg/service-api/endpoints/installer.go
+++ b/resource-management/pkg/service-api/endpoints/installer.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"k8s.io/klog/v2"
 	"net/http"
+	"strings"
 
 	di "global-resource-service/resource-management/pkg/common-lib/interfaces/distributor"
 	store "global-resource-service/resource-management/pkg/common-lib/interfaces/store"
@@ -42,6 +43,7 @@ func (i *Installer) ClientAdministrationHandler(resp http.ResponseWriter, req *h
 
 // TODO: error handling function
 func (i *Installer) handleClientRegistration(resp http.ResponseWriter, req *http.Request) {
+	klog.Infof("handle client registration")
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		klog.V(3).Infof("error read request. error %v", err)
@@ -108,8 +110,8 @@ func (i *Installer) ResourceHandler(resp http.ResponseWriter, req *http.Request)
 
 	switch req.Method {
 	case http.MethodGet:
-		ctx := req.Context()
-		clientId := ctx.Value("clientid").(string)
+		// urlpath is fixed: "/resource/clientid"
+		clientId := strings.Split(req.URL.Path, "/")[2]
 
 		if req.URL.Query().Get(WatchParameter) == WatchParameterTrue {
 			i.serverWatch(resp, req, clientId)

--- a/resource-management/pkg/service-api/endpoints/installer_test.go
+++ b/resource-management/pkg/service-api/endpoints/installer_test.go
@@ -1,8 +1,8 @@
 package endpoints
 
 import (
-	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -86,7 +86,7 @@ func TestHttpGet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resourcePath := RegionlessResourcePath + "/" + clientId
+	resourcePath := fmt.Sprintf("%s/%s", RegionlessResourcePath, clientId)
 	req, err := http.NewRequest(http.MethodGet, resourcePath, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -94,9 +94,7 @@ func TestHttpGet(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	ctx := context.WithValue(req.Context(), "clientid", clientId)
-
-	installer.ResourceHandler(recorder, req.WithContext(ctx))
+	installer.ResourceHandler(recorder, req)
 
 	actualNodes := make([]types.LogicalNode, 0)
 	decNodes := make([]types.LogicalNode, 0)

--- a/resource-management/test/registerClient.json
+++ b/resource-management/test/registerClient.json
@@ -1,0 +1,9 @@
+{
+  "client_info": {
+    "client_name": "testclient",
+    "client_region": "beijing"
+  },
+  "init_resource_request": {
+    "total_machines": 2000
+  }
+}


### PR DESCRIPTION
client register and list test

```
yunwens-mbp:resource-management yunwenbai$ curl -X POST http://localhost:8080/clients -d @test/registerClient.json | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   245  100   102  100   143     12     17  0:00:08  0:00:08 --:--:--    26
{
  "client_id": "Client-dddadfde-f4a0-425c-8758-9c1173456fdb",
  "granted_resource": {
    "total_machines": 2000
  }
}
yunwens-mbp:resource-management yunwenbai$ curl http://localhost:8080/resource/Client-dddadfde-f4a0-425c-8758-9c1173456fdb | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0[
  {
    "Id": "e4c7c669-eeb2-4dd7-b7db-7702d92d749b",
    "ResourceVersion": "11865",
    "GeoInfo": {
      "Region": 8,
      "ResourcePartition": 6,
      "DataCenter": "3785-DataCenter",
      "AvailabilityZone": "AZ-0",
      "FaultDomain": "e4c7c669-eeb2-4dd7-b7db-7702d92d749b-FaultDomain"
    },
    "Taints": {
      "NoSchedule": false,
      "NoExecute": false
    },
    "SpecialHardwareTypes": {
      "HasGpu": true,
      "HasFPGA": true
    },
    "AllocatableResource": {
      "MilliCPU": 29,
      "Memory": 374,
      "EphemeralStorage": 1751524,
      "AllowedPodNumber": 8099709,
      "ScalarResources": {
        "FPGA": 94,
        "GPU": 49
      }
    },
```