### PR TITLE
give out-of-package access to location fileds. this is needed for REST calls as part of the CRV

### DIFF
--- a/resource-management/pkg/common-lib/types/location/location.go
+++ b/resource-management/pkg/common-lib/types/location/location.go
@@ -8,14 +8,14 @@ import (
 const RingRange = float64(360)
 
 type Location struct {
-	region    Region
-	partition ResourcePartition
+	Region    Region
+	Partition ResourcePartition
 }
 
 func NewLocation(region Region, partition ResourcePartition) *Location {
 	return &Location{
-		region:    region,
-		partition: partition,
+		Region:    region,
+		Partition: partition,
 	}
 }
 
@@ -208,8 +208,8 @@ func init() {
 		for j := 0; j < len(rps); j++ {
 			rp := rps[j]
 			loc := Location{
-				region:    region,
-				partition: rp,
+				Region:    region,
+				Partition: rp,
 			}
 			if j == len(rps)-1 {
 				if i == len(Regions)-1 {
@@ -247,11 +247,11 @@ func GetRPsForRegion(region Region) []ResourcePartition {
 }
 
 func (loc *Location) GetRegion() Region {
-	return loc.region
+	return loc.Region
 }
 
 func (loc *Location) GetResourcePartition() ResourcePartition {
-	return loc.partition
+	return loc.Partition
 }
 
 func (loc *Location) GetArcRangeFromLocation() (float64, float64) {
@@ -260,11 +260,11 @@ func (loc *Location) GetArcRangeFromLocation() (float64, float64) {
 }
 
 func (loc *Location) Equal(locToCompare Location) bool {
-	return loc.region == locToCompare.region && loc.partition == locToCompare.partition
+	return loc.Region == locToCompare.Region && loc.Partition == locToCompare.Partition
 }
 
 func (loc *Location) String() string {
-	return fmt.Sprintf("[Region %s, ResoucePartition %s]", loc.region, loc.partition)
+	return fmt.Sprintf("[Region %s, ResoucePartition %s]", loc.Region, loc.Partition)
 }
 
 func (loc Location) MarshalText() (text []byte, err error) {

--- a/resource-management/pkg/common-lib/types/location/location_test.go
+++ b/resource-management/pkg/common-lib/types/location/location_test.go
@@ -25,12 +25,12 @@ func TestLocationInit(t *testing.T) {
 		for j := 0; j < len(rps); j++ {
 			rp := rps[j]
 			loc := Location{
-				region:    region,
-				partition: rp,
+				Region:    region,
+				Partition: rp,
 			}
 			lower, upper := loc.GetArcRangeFromLocation()
 			if preLower >= lower || preUpper >= upper || lower < 0 || upper > RingRange || (preUpper > 0 && preUpper != lower) {
-				assert.Fail(t, "Invalid ranges for region/resource paritions", "RP %s has unexpected hash range (%f, %f]\n\n", loc.partition, lower, upper)
+				assert.Fail(t, "Invalid ranges for region/resource paritions", "RP %s has unexpected hash range (%f, %f]\n\n", loc.Partition, lower, upper)
 				t.Log("All hash range listed as follows:\n")
 				printLocationRange(t)
 				assert.Fail(t, "")
@@ -51,8 +51,8 @@ func printLocationRange(t *testing.T) {
 		for j := 0; j < len(rps); j++ {
 			rp := rps[j]
 			loc := Location{
-				region:    region,
-				partition: rp,
+				Region:    region,
+				Partition: rp,
 			}
 			lower, upper := loc.GetArcRangeFromLocation()
 			t.Logf("%s, %s, [%f, %f]\n", region, rp, lower, upper)
@@ -129,8 +129,8 @@ func TestGetLocationRangeByObject_Performance(t *testing.T) {
 		for j := 0; j < len(ResourcePartitions); j++ {
 			pos := i*len(ResourcePartitions) + j
 			locations[pos] = Location{
-				region:    Regions[i],
-				partition: ResourcePartitions[j],
+				Region:    Regions[i],
+				Partition: ResourcePartitions[j],
 			}
 		}
 	}


### PR DESCRIPTION
the region and partition of the Location type is needed to be in REST req and resp for the CRVs. the fileds is currently accessible only for in-package functions, which causes the CRV is not transmitted in REST calls. below is an example with the region service simulator and aggregators in the POSTCRV calls.

the sim.log is from the simulator where the CRVs are posted and the t.log is the aggregrator which pushes the CRVs. you can see 10 in the map with the values and only one shows in the simulator with fake values. 

with this PR, all 10 shows in both sides.

```
yunwens-mbp:resource-management yunwenbai$ grep -i debug sim.log
I0623 16:09:05.093987   69241 regionNodeEvents.go:110] debug: CRV is map[{0 0}:5000]
I0623 16:09:05.094020   69241 regionNodeEvents.go:113] debug: RV in map, key: Beijing-RP1, value: 5000
I0623 16:09:21.871014   69241 regionNodeEvents.go:110] debug: CRV is map[{0 0}:5000]
I0623 16:09:21.871035   69241 regionNodeEvents.go:113] debug: RV in map, key: Beijing-RP1, value: 5000
yunwens-mbp:resource-management yunwenbai$ grep -i debug t.log
I0623 16:09:05.093517   69251 aggregator.go:183] debug: CRV is map[{8 0}:5000 {8 1}:5000 {8 2}:5000 {8 3}:5000 {8 4}:5000 {8 5}:5000 {8 6}:5000 {8 7}:5000 {8 8}:5000 {8 9}:5000]
I0623 16:09:05.093573   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP8, value: 5000
I0623 16:09:05.093590   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP10, value: 5000
I0623 16:09:05.093599   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP1, value: 5000
I0623 16:09:05.093607   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP2, value: 5000
I0623 16:09:05.093616   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP3, value: 5000
I0623 16:09:05.093624   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP4, value: 5000
I0623 16:09:05.093633   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP7, value: 5000
I0623 16:09:05.093642   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP5, value: 5000
I0623 16:09:05.093651   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP6, value: 5000
I0623 16:09:05.093659   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP9, value: 5000
I0623 16:09:21.870676   69251 aggregator.go:183] debug: CRV is map[{8 0}:5000 {8 1}:5000 {8 2}:5000 {8 3}:5000 {8 4}:5000 {8 5}:5000 {8 6}:5000 {8 7}:5000 {8 8}:5000 {8 9}:5000]
I0623 16:09:21.870712   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP3, value: 5000
I0623 16:09:21.870722   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP5, value: 5000
I0623 16:09:21.870728   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP8, value: 5000
I0623 16:09:21.870733   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP9, value: 5000
I0623 16:09:21.870739   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP10, value: 5000
I0623 16:09:21.870744   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP2, value: 5000
I0623 16:09:21.870750   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP4, value: 5000
I0623 16:09:21.870755   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP6, value: 5000
I0623 16:09:21.870761   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP7, value: 5000
I0623 16:09:21.870766   69251 aggregator.go:186] debug: RV in map, key: Reserved5-RP1, value: 5000
```