### PR TITLE
[BugFix]: Tuning Redis Client parameters to ensure current Redis can support 250K nodes in one region

### DIFF
--- a/resource-management/pkg/aggregrator/aggregator.go
+++ b/resource-management/pkg/aggregrator/aggregator.go
@@ -87,14 +87,14 @@ func (a *Aggregator) Run() (err error) {
 				// otherwise the method subsequentPull is called.
 				// To simplify the codes, we use one method initPullOrSubsequentPull instead
 				regionNodeEvents, length = a.initPullOrSubsequentPull(c, DefaultBatchLength, crv)
-				klog.Infof("Total (%v) region node events are pulled successfully in (%v)", len(regionNodeEvents), length)
+				klog.Infof("Total (%v) region node events are pulled successfully in (%v) RPs", length, len(regionNodeEvents))
 
 				// Convert 2D array to 1D array
 				var minRecordNodeEvents []*event.NodeEvent
 				for j := 0; j < len(regionNodeEvents); j++ {
 					minRecordNodeEvents = append(minRecordNodeEvents, regionNodeEvents[j]...)
 				}
-				klog.Infof("Total (%v) mini node events are converted successfully in (%v)", len(minRecordNodeEvents), length)
+				klog.Infof("Total (%v) mini node events are converted successfully with length (%v)", len(minRecordNodeEvents), length)
 
 				if len(minRecordNodeEvents) != 0 {
 					// Call ProcessEvents() and get the CRV from distributor as default success

--- a/resource-management/pkg/store/redis/redis.go
+++ b/resource-management/pkg/store/redis/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -22,9 +23,14 @@ type Goredis struct {
 // TODO: with configured parameters for the store
 func NewRedisClient() *Goredis {
 	client := redis.NewClient(&redis.Options{
-		Addr:     "localhost:6379",
-		Password: "", //no password set
-		DB:       0,  // use default DB
+		Addr:		"localhost:6379",
+		PoolSize:	1000,
+		PoolTimeout:	2 * time.Minute,
+		IdleTimeout:	10 * time.Minute,
+		ReadTimeout:	2 * time.Minute,
+		WriteTimeout:	1 * time.Minute,
+		Password:	"", //no password set
+		DB:		0,  // use default DB
 	})
 
 	ctx := context.Background()

--- a/resource-management/test/resourceRegionMgrSimulator/app/simulator.go
+++ b/resource-management/test/resourceRegionMgrSimulator/app/simulator.go
@@ -52,9 +52,8 @@ func Run(c *RegionConfig) error {
 	s := &http.Server{
 		Addr:         bindAddress,
 		Handler:      sm,
-		IdleTimeout:  120 * time.Second,
-		ReadTimeout:  3600 * time.Second,
-		WriteTimeout: 3600 * time.Second,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
 	}
 
 	go func() {

--- a/resource-management/test/resourceRegionMgrSimulator/handlers/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/handlers/regionNodeEvents.go
@@ -80,7 +80,7 @@ func (re *RegionNodeEventHandler) SimulatorHandler(rw http.ResponseWriter, r *ht
 		if len(nodeEvents) == 0 {
 			klog.Info("Pulling Region Node Events with batch is in the end")
 		} else {
-			klog.Infof("Pulling Region Node Event with final batch size (%v) for (%v) regions", count, len(nodeEvents))
+			klog.Infof("Pulling Region Node Event with final batch size (%v) for (%v) RPs", count, len(nodeEvents))
 
 			response := &simulatorTypes.ResponseFromRRM{
 				RegionNodeEvents: nodeEvents,


### PR DESCRIPTION
This PR is to do redis Client parameter tuning for fixing the "error redis: connection pool timeout"

The changes are tested on the following one machine successfully.

1) resource-management + redis server + resource region manager simulator  : ubuntu@ip-172-31-8-82 ( AWS EC2 instance running U1804)

Also, the changes are tested on the following three machines successfully.

1) resource-management + redis server: ubuntu@ip-172-31-8-82 ( AWS t2.2xlarge EC2 instance running U1804)
2) resource region manager simulator 1: ubuntu@ip-172-31-8-205 ( AWS t2.2xlarge EC2 instance running U1804)
3) resource region manager simulator 2: ubuntu@ip-172-31-7-9  ( AWS t2.2xlarge EC2 instance running U1804)

Need tune the parameter file descriptor on three EC2 instances (2 simulators + resource management & redis) and reboot in terms of the following doc:
https://superuser.com/questions/1200539/cannot-increase-open-file-limit-past-4096-ubuntu.

$ ulimit -n -Hn  -Sn
open files                      (-n) 65535
open files                      (-n) 65535
open files                      (-n) 65535

Otherwise, aggregator EC2 instance will has the following complaining to two simulators. 

E0624 02:43:00.908258   10296 aggregator.go:162] Get http://ec2-34-220-203-225.us-west-2.compute.amazonaws.com:9119/resources/subsequentpull: dial tcp: lookup ec2-34-220-203-225.us-west-2.compute.amazonaws.com: too many open files

E0624 02:43:00.908291   10296 aggregator.go:162] Get http://ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9119/resources/subsequentpull: dial tcp: lookup ec2-52-24-162-197.us-west-2.compute.amazonaws.com: too many open files


Right now, per the current test result, distributor can take 500K nodes from 2 resource region manager simulators.

Above tests with 3 AWS EC2 instances have kept running successfully since last night 11:40pm PDT around

