### PR TITLE
fix issue in goroutine sync

### DIFF
--- a/resource-management/pkg/distributor/storage/memorycache.go
+++ b/resource-management/pkg/distributor/storage/memorycache.go
@@ -30,13 +30,15 @@ func (c *DistributorPersistHelper) SetWaitCount(count int) {
 
 func (c *DistributorPersistHelper) PersistNode(newNode *types.LogicalNode) {
 	go func(persistHelper store.StoreInterface, node *types.LogicalNode, wg *sync.WaitGroup) {
+		wg.Add(1)
+		defer wg.Done()
 		for {
 			result := persistHelper.PersistNodes([]*types.LogicalNode{newNode})
 			if result {
-				wg.Done()
 				return
 			} else {
 				// TODO - error processing
+				return
 			}
 		}
 	}(c.persistHelper, newNode, c.persistNodeWaitGroup)

--- a/resource-management/pkg/distributor/storage/nodestore.go
+++ b/resource-management/pkg/distributor/storage/nodestore.go
@@ -246,8 +246,6 @@ func (ns NodeStore) DeleteNode(nodeEvent event.NodeEvent) {
 }
 
 func (ns *NodeStore) ProcessNodeEvents(nodeEvents []*node.ManagedNodeEvent, persistHelper *DistributorPersistHelper) (bool, types.ResourceVersionMap) {
-	persistHelper.SetWaitCount(len(nodeEvents))
-
 	for _, e := range nodeEvents {
 		if e == nil {
 			break


### PR DESCRIPTION
this is to ensure wait count and goroutine setup correctly. we hit an issue where the service hangs, when the aggregator has a few nils in the node event slice. anyway, setting up the waitcount too early previously and can get into this hang for other reasons. 