### PR TITLE
[bugfix/Simulator]Re-index for updated events per RP without nil events to be uploaded from simulator

### DIFF
--- a/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
@@ -89,8 +89,8 @@ func GetRegionNodeModifiedEventsCRV(rvs types.ResourceVersionMap) (simulatorType
 
 	var count uint64 = 0
 	for j := 0; j < RpNum; j++ {
-
-		pulledNodeListEvents[j] = make([]*event.NodeEvent, NodesPerRP)
+		pulledNodeListEventsPerRP := make([]*event.NodeEvent, NodesPerRP)
+		indexPerRP := 0
 		for i := 0; i < NodesPerRP; i++ {
 			region := snapshotNodeListEvents[j][i].Node.GeoInfo.Region
 			rp := snapshotNodeListEvents[j][i].Node.GeoInfo.ResourcePartition
@@ -98,9 +98,12 @@ func GetRegionNodeModifiedEventsCRV(rvs types.ResourceVersionMap) (simulatorType
 
 			if snapshotNodeListEvents[j][i].Node.GetResourceVersionInt64() > rvs[*loc] {
 				count += 1
-				pulledNodeListEvents[j][i] = snapshotNodeListEvents[j][i]
+				pulledNodeListEventsPerRP[indexPerRP] = snapshotNodeListEvents[j][i]
+				indexPerRP += 1
 			}
 		}
+
+		pulledNodeListEvents[j] = pulledNodeListEventsPerRP[:indexPerRP]
 	}
 
 	klog.Infof("Total (%v) Modified events are to be pulled", count)


### PR DESCRIPTION
This PR is to fix the issue - in the resource region manager simulator, when the updated events are created for each RP, index from the source is used, which ends up a lot of nil elements in the array to be uploaded to aggregator. The new index records the length of real updated events in the slice to be uploaded to aggregator correctly.

The codes have been tested under AWS EC2 Ubuntu 18.04 environment (1 x resource service  & redis + 2 x resource region manager simulators).