### PR TITLE
[BugFix] update help usage with region_name instead of region_id

### DIFF
--- a/resource-management/test/resourceRegionMgrSimulator/main.go
+++ b/resource-management/test/resourceRegionMgrSimulator/main.go
@@ -62,7 +62,7 @@ func main() {
 // function to print the usage info for the resource management api server
 func printUsage() {
 	fmt.Println("\nUsage: Region Resource Manager Simulator")
-	fmt.Println("\n       Per region config options: --region_id=<region Identifier>  --rp_num=<number of rp>  --nodes_per_rp=<number of nodes> --master_port=<port>")
+	fmt.Println("\n       Per region config options: --region_name=<region name>  --rp_num=<number of rp>  --nodes_per_rp=<number of nodes> --master_port=<port>")
 	fmt.Println()
 
 	os.Exit(0)


### PR DESCRIPTION
This PR is to make two minor changes

Adjust aggregator pulling interval from simulators from 100ms to 1000ms
Update help usage with region_name instead of region_id after PR46 changes region_id to region_name for command line input parameters of resource region manager simulator.