### PR TITLE
installer to send node event to client

### DIFF
--- a/resource-management/pkg/service-api/endpoints/installer.go
+++ b/resource-management/pkg/service-api/endpoints/installer.go
@@ -219,9 +219,9 @@ func (i *Installer) serverWatch(resp http.ResponseWriter, req *http.Request, cli
 				return
 			}
 
-			klog.V(3).Infof("Getting event from distributor: %v", record)
+			klog.V(9).Infof("Getting event from distributor: %v, %v", *record, *record.Node)
 
-			if err := json.NewEncoder(resp).Encode(*record.Node); err != nil {
+			if err := json.NewEncoder(resp).Encode(*record); err != nil {
 				klog.V(3).Infof("encoding record failed. error %v", err)
 				resp.WriteHeader(http.StatusInternalServerError)
 				return


### PR DESCRIPTION
random pick up a couple record from server and client logs:

```
yunwens-mbp:resource-management yunwenbai$ grep b11399a9-fff7-429b-9fd3-2043c4808afa t.log
I0628 21:19:55.450521   54426 installer.go:222] Getting event from distributor: {MODIFIED 0xc0023dfad0}, {b11399a9-fff7-429b-9fd3-2043c4808afa 11612 {0 0 6039-DataCenter AZ-1 b11399a9-fff7-429b-9fd3-2043c4808afa-FaultDomain} {false false} {true true} {166 983 310928 7325516 map[FPGA:77 GPU:126]} 111 false b11399a9-fff7-429b-9fd3-2043c4808afa-highend}
yunwens-mbp:resource-management yunwenbai$ grep fa0aaebb-00e1-425c-ae8e-9c743d4240a0 11618 t.log
grep: 11618: No such file or directory
t.log:I0628 21:19:55.483470   54426 installer.go:222] Getting event from distributor: {MODIFIED 0xc006f37e40}, {fa0aaebb-00e1-425c-ae8e-9c743d4240a0 11618 {0 0 8419-DataCenter AZ-2 fa0aaebb-00e1-425c-ae8e-9c743d4240a0-FaultDomain} {false false} {true true} {152 1381 1472586 12984170 map[FPGA:168 GPU:105]} 111 false fa0aaebb-00e1-425c-ae8e-9c743d4240a0-highend}
yunwens-mbp:resource-management yunwenbai$ 
```

```
I0628 21:19:55.451490   54477 singleClientTest.go:88] Received node from server: {MODIFIED 0xc000239ce0}, {b11399a9-fff7-429b-9fd3-2043c4808afa 11612 {0 0 6039-DataCenter AZ-1 b11399a9-fff7-429b-9fd3-2043c4808afa-FaultDomain} {false false} {true true} {166 983 310928 7325516 map[FPGA:77 GPU:126]} 111 false b11399a9-fff7-429b-9fd3-2043c4808afa-highend}

I0628 21:21:20.217174   54477 singleClientTest.go:88] Received node from server: {MODIFIED 0xc00043dad0}, {fa0aaebb-00e1-425c-ae8e-9c743d4240a0 11618 {0 0 8419-DataCenter AZ-2 fa0aaebb-00e1-425c-ae8e-9c743d4240a0-FaultDomain} {false false} {true true} {152 1381 1472586 12984170 map[FPGA:168 GPU:105]} 111 false fa0aaebb-00e1-425c-ae8e-9c743d4240a0-highend}
```