### PR TITLE
[BugFix] Use <master address> instead of <ip address> and add explanation to <master address>

### DIFF
--- a/resource-management/cmds/service-api/service-api.go
+++ b/resource-management/cmds/service-api/service-api.go
@@ -57,7 +57,8 @@ func printUsage() {
 	// klog will use commandline log parameters with nil as named a few below:
 	// --alsologtostderr=true  --logtostderr=false --log_file="/tmp/grs.log"
 	fmt.Println("logging options: --alsologtostderr=true  --logtostderr=false --log_file=/tmp/grs.log ")
-	fmt.Println("service config options: --master_ip=<ip address>  --master_port=<port> --resource_urls=<url1,url2,...>")
+	fmt.Println("service config options: --master_ip=<master address>  --master_port=<port> --resource_urls=<url1,url2,...>")
+	fmt.Println("Explanation: <master address> could be public ip address or public dns name of the server")
 
 	os.Exit(0)
 }


### PR DESCRIPTION
This PR is to update correct help message using "master address" instead of "ip address" and add explanation to "master address" more accurately because using --master_ip=34.214.160.3 does not work but using --master_ip=ec2-34-214-160-3.us-west-2.compute.amazonaws.com does work 

--- not working
$ /usr/local/go/bin/go run service-api.go --master_ip=34.214.160.3 --resource_urls=ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9119,ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9129                                            
```
I0629 23:37:10.761998    1784 service-api.go:42] Service config: &{[ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9119 ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9129] 34.214.160.3 8080}
I0629 23:37:10.762081    1784 service-api.go:44] Starting resource management service
I0629 23:37:10.914984    1784 server.go:44] Serving at 34.214.160.3:8080
I0629 23:37:10.915320    1784 service-api.go:50] Exiting resource management service
```

--- working
$ /usr/local/go/bin/go run service-api.go --master_ip=ec2-34-214-160-3.us-west-2.compute.amazonaws.com --resource_urls=ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9119,ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9129
```
I0629 23:49:45.839043    2448 service-api.go:42] Service config: &{[ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9119 ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9129] ec2-34-214-160-3.us-west-2.compute.amazonaws.com 8080}
I0629 23:49:45.839135    2448 service-api.go:44] Starting resource management service
I0629 23:49:45.987384    2448 server.go:44] Serving at ec2-34-214-160-3.us-west-2.compute.amazonaws.com:8080
```