### PR TITLE
Improve LogLevel of aggregator and simulator for easy test environment setup

### DIFF
--- a/resource-management/test/resourceRegionMgrSimulator/app/simulator.go
+++ b/resource-management/test/resourceRegionMgrSimulator/app/simulator.go
@@ -57,7 +57,7 @@ func Run(c *RegionConfig) error {
 	}
 
 	go func() {
-		klog.Infof("\nStarting resource region manager simulator server on port (%v)", c.MasterPort)
+		klog.V(3).Infof("\nStarting resource region manager simulator server on port (%v)", c.MasterPort)
 
 		err := s.ListenAndServe()
 		if err != nil {
@@ -69,7 +69,7 @@ func Run(c *RegionConfig) error {
 	signal.Notify(sigChan, os.Interrupt)
 
 	sig := <-sigChan
-	klog.Infof("\n\nReceived terminate, graceful shutdown\n\n", sig)
+	klog.V(3).Infof("\n\nReceived terminate, graceful shutdown\n\n", sig)
 
 	tc, err := context.WithTimeout(context.Background(), 30*time.Second)
 	if err != nil {

--- a/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
@@ -51,17 +51,17 @@ func MakeDataUpdate() {
 			// At 2th minute mark, generate 5k modified and added node events
 			time.Sleep(2 * time.Minute)
 			makeDataUpdate(at2thMin5k)
-			klog.Info("At 2th minute mark, generating 5k modified and added node events is completed")
+			klog.V(3).Info("At 2th minute mark, generating 5k modified and added node events is completed")
 
 			// At 5th time mark, generate 25k modified node events
 			time.Sleep(3 * time.Minute)
 			makeDataUpdate(at5thMin25k)
-			klog.Info("At 5th time mark, generating 25k modified node events is completed")
+			klog.V(3).Info("At 5th time mark, generating 25k modified node events is completed")
 
 			// At 7th time mark, generate 1k modified events
 			time.Sleep(2 * time.Minute)
 			makeDataUpdate(at7thMin1k)
-			klog.Info("At 7th time mark, generating 1k modified events is completed")
+			klog.V(3).Info("At 7th time mark, generating 1k modified events is completed")
 		}
 	}()
 }
@@ -74,7 +74,7 @@ func MakeDataUpdate() {
 // TO DO: paginate support
 //
 func GetRegionNodeAddedEvents(batchLength uint64) (simulatorTypes.RegionNodeEvents, uint64) {
-	klog.Infof("Total (%v) Added events are to be pulled", RpNum*NodesPerRP)
+	klog.V(6).Infof("Total (%v) Added events are to be pulled", RpNum*NodesPerRP)
 	return RegionNodeEventsList, uint64(RpNum * NodesPerRP)
 
 }
@@ -105,7 +105,7 @@ func GetRegionNodeModifiedEventsCRV(rvs types.ResourceVersionMap) (simulatorType
 		pulledNodeListEvents[j] = pulledNodeListEventsPerRP[:indexPerRP]
 	}
 
-	klog.Infof("Total (%v) Modified events are to be pulled", count)
+	klog.V(9).Infof("Total (%v) Modified events are to be pulled", count)
 	return pulledNodeListEvents, count
 }
 
@@ -182,7 +182,7 @@ func makeDataUpdate(changesThreshold int) {
 		}
 	}
 
-	klog.Infof("Actually total (%v) new modified events are created.", changesThreshold)
+	klog.V(6).Infof("Actually total (%v) new modified events are created.", changesThreshold)
 }
 
 // Create logical node with random UUID

--- a/resource-management/test/resourceRegionMgrSimulator/handlers/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/handlers/regionNodeEvents.go
@@ -19,15 +19,15 @@ func NewRegionNodeEventsHander() *RegionNodeEventHandler {
 
 func (re *RegionNodeEventHandler) SimulatorHandler(rw http.ResponseWriter, r *http.Request) {
 
-	klog.Infof("Handle /resources. URL path: %s", r.URL.Path)
+	klog.V(9).Infof("Handle /resources. URL path: %s", r.URL.Path)
 
 	// Check URL Path received from aggregator client side
 	if r.URL.Path == InitPullPath {
-		klog.Info("Handle GET all region node added events via initPull")
+		klog.V(9).Info("Handle GET all region node added events via initPull")
 	} else if r.URL.Path == SubsequentPullPath {
-		klog.Info("Handle GET all region node modified events via SubsequentPull")
+		klog.V(9).Info("Handle GET all region node modified events via SubsequentPull")
 	} else if r.URL.Path == PostCRVPath {
-		klog.Info("Handle POST CRV to discard all old region node modified events")
+		klog.V(9).Info("Handle POST CRV to discard all old region node modified events")
 	} else {
 		klog.Errorf("Error: The current URL (%v) is not supported!", r.URL.Path)
 		rw.WriteHeader(http.StatusBadRequest)
@@ -77,28 +77,30 @@ func (re *RegionNodeEventHandler) SimulatorHandler(rw http.ResponseWriter, r *ht
 			nodeEvents, count = data.GetRegionNodeModifiedEventsCRV(aggregatorClientReq.CRV)
 		}
 
-		if len(nodeEvents) == 0 {
-			klog.Info("Pulling Region Node Events with batch is in the end")
+		if count == 0 {
+			klog.V(9).Info("Pulling Region Node Events with batch is in the end")
 		} else {
-			klog.Infof("Pulling Region Node Event with final batch size (%v) for (%v) RPs", count, len(nodeEvents))
+			klog.V(6).Infof("Pulling Region Node Event with final batch size (%v) for (%v) RPs", count, len(nodeEvents))
+		}
 
-			response := &simulatorTypes.ResponseFromRRM{
-				RegionNodeEvents: nodeEvents,
-				RvMap:            aggregatorClientReq.CRV,
-				Length:           uint64(count),
-			}
+		response := &simulatorTypes.ResponseFromRRM{
+			RegionNodeEvents: nodeEvents,
+			RvMap:            aggregatorClientReq.CRV,
+			Length:           uint64(count),
+		}
 
-			// Serialize region node events result to JSON
-			err = response.ToJSON(rw)
+		// Serialize region node events result to JSON
+		err = response.ToJSON(rw)
 
-			if err != nil {
-				klog.Errorf("Error - Unable to marshal json : ", err)
-			}
+		if err != nil {
+			klog.Errorf("Error - Unable to marshal json : ", err)
+		}
 
+		if count != 0 {
 			if r.URL.Path == InitPullPath {
-				klog.Info("Handle GET all region node added events via initPull successfully")
+				klog.V(3).Infof("Handle GET all (%v) region node added events via initPull successfully", count)
 			} else {
-				klog.Info("Handle GET all region node modified events via SubsequentPull succesfully")
+				klog.V(3).Infof("Handle GET all (%v) region node modified events via SubsequentPull succesfully", count)
 			}
 		}
 
@@ -114,6 +116,6 @@ func (re *RegionNodeEventHandler) SimulatorHandler(rw http.ResponseWriter, r *ht
 			klog.Errorf("Error - Unable to marshal json : ", err)
 		}
 
-		klog.Info("Handle POST CRV to discard all old region node modified events successfully")
+		klog.V(3).Info("Handle POST CRV to discard all old region node modified events successfully")
 	}
 }


### PR DESCRIPTION
This PR is to set loglevel3,6,9 for all klog information of resource aggregator and resource region manager simulator so that setting up testing environment is easier than before.

The codes have been tested successfully with global resource service AWS EC2 instance + resource region region manager on AWS EC2 instance which are running on Ubuntu 20.04 + golang 1.17.11.

1. logLevel = 3
```
ubuntu@ip-172-31-4-135:~/go/src/global-resource-service/resource-management/cmds/service-api$ go run service-api.go --resource_urls=localhost:9129 -v=3
ubuntu@ip-172-31-4-135:~/go/src/global-resource-service/resource-management/test/resourceRegionMgrSimulator$ go run main.go --region_name=Beijing --rp_num=20 --nodes_per_rp=10000 --master_port=9129 -v=3
```

2. logLevel = 6
```
ubuntu@ip-172-31-4-135:~/go/src/global-resource-service/resource-management/cmds/service-api$ go run service-api.go --resource_urls=localhost:9129 -v=6
ubuntu@ip-172-31-4-135:~/go/src/global-resource-service/resource-management/test/resourceRegionMgrSimulator$ go run main.go --region_name=Beijing --rp_num=20 --nodes_per_rp=10000 --master_port=9129 -v=6

```

3. logLevel = 9
```
ubuntu@ip-172-31-4-135:~/go/src/global-resource-service/resource-management/cmds/service-api$ go run service-api.go --resource_urls=localhost:9129 -v=9
ubuntu@ip-172-31-4-135:~/go/src/global-resource-service/resource-management/test/resourceRegionMgrSimulator$ go run main.go --region_name=Beijing --rp_num=20 --nodes_per_rp=10000 --master_port=9129 -v=9


```