### PR TITLE
Add field LastUpdatedTime into LogicalNode struct

### DIFF
--- a/resource-management/pkg/common-lib/types/logicalNode.go
+++ b/resource-management/pkg/common-lib/types/logicalNode.go
@@ -2,8 +2,10 @@ package types
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"strconv"
+	"time"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -97,6 +99,9 @@ type LogicalNode struct {
 	// defined as highend, lowend, medium as an example
 	// TBD for post 630
 	MachineType NodeMachineType
+
+	// LastUpdatedTime defines the time when node status was updated in resource partition
+	LastUpdatedTime time.Time
 }
 
 func (n *LogicalNode) Copy() *LogicalNode {

--- a/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
@@ -174,6 +174,8 @@ func makeDataUpdate(changesThreshold int) {
 			} else {
 				node.ResourceVersion = strconv.FormatUint(currentResourceVersion+1, 10)
 			}
+			// record the time to change resource version in resource partition
+			node.LastUpdatedTime = time.Now()
 
 			newEvent := event.NewNodeEvent(node, event.Modified)
 			RegionNodeEventsList[j][i] = newEvent
@@ -218,8 +220,9 @@ func createRandomNode(rv int, loc *location.Location) *types.LogicalNode {
 				"FPGA": int64(rand.Intn(200)),
 			},
 		},
-		Conditions:  111,
-		Reserved:    false,
-		MachineType: types.NodeMachineType(id.String() + "-highend"),
+		Conditions:      111,
+		Reserved:        false,
+		MachineType:     types.NodeMachineType(id.String() + "-highend"),
+		LastUpdatedTime: time.Now(),
 	}
 }


### PR DESCRIPTION
This PR is to add field 'LastUpdatedTime' into logicalNode struct and update time to this field when added/modified node events are created/updated.

The codes have been tested in my Mac Development server successfully. 

127.0.0.1:6379> get MinNode.67f432fd-56cb-47ff-976d-21f19c078312.0.3

```
"{\"Id\":\"67f432fd-56cb-47ff-976d-21f19c078312\",\"ResourceVersion\":\"235\",\"GeoInfo\":{\"Region\":0,\"ResourcePartition\":3,\"DataCenter\":\"7198-DataCenter\",\"AvailabilityZone\":\"AZ-3\",\"FaultDomain\":\"67f432fd-56cb-47ff-976d-21f19c078312-FaultDomain\"},\"Taints\":{\"NoSchedule\":false,\"NoExecute\":false},\"SpecialHardwareTypes\":{\"HasGpu\":true,\"HasFPGA\":true},\"AllocatableResource\":{\"MilliCPU\":132,\"Memory\":1131,\"EphemeralStorage\":1214043,\"AllowedPodNumber\":5244171,\"ScalarResources\":{\"FPGA\":83,\"GPU\":187}},\"Conditions\":111,\"Reserved\":false,\"MachineType\":\"67f432fd-56cb-47ff-976d-21f19c078312-highend\",
\"LastUpdatedTime\":\"2022-07-01T18:19:16.087738-07:00\"}
```