### PR TITLE
periodically dump event metrics

### DIFF
--- a/resource-management/cmds/service-api/service-api.go
+++ b/resource-management/cmds/service-api/service-api.go
@@ -21,7 +21,8 @@ func main() {
 	flag.StringVar(&c.MasterIp, "master_ip", "localhost", "Service IP address, if not set, default to localhost")
 	flag.StringVar(&c.MasterPort, "master_port", "8080", "Service port, if not set, default to 8080")
 	flag.StringVar(&urls, "resource_urls", "", "Resource urls of the resource manager services in each region")
-
+	flag.DurationVar(&c.EventMetricsDumpFrequency, "metrics_dump_frequency", 5*time.Minute, "Frequency to dump the event metrics, default 5m")
+	
 	if !flag.Parsed() {
 		klog.InitFlags(nil)
 		flag.Parse()


### PR DESCRIPTION
```
I0713 09:10:08.895579   43484 event_metrics.go:94] [Metrics][AGG_RECEIVED] perc50 250.483ms, perc90 351.359ms, perc99 353.909ms. Total count 11986
I0713 09:10:08.895660   43484 event_metrics.go:95] [Metrics][DIS_RECEIVED] perc50 254.12ms, perc90 361.455ms, perc99 365.714ms. Total count 11986
I0713 09:10:08.895681   43484 event_metrics.go:96] [Metrics][DIS_SENDING] perc50 274.987ms, perc90 437.195ms, perc99 484.997ms. Total count 11986
I0713 09:10:08.895696   43484 event_metrics.go:97] [Metrics][DIS_SENT] perc50 274.955ms, perc90 437.138ms, perc99 484.997ms. Total count 11960
I0713 09:10:08.895711   43484 event_metrics.go:98] [Metrics][SER_ENCODED] perc50 275.422ms, perc90 437.807ms, perc99 485.225ms. Total count 11986
I0713 09:10:08.895725   43484 event_metrics.go:99] [Metrics][SER_SENT] perc50 275.429ms, perc90 437.81ms, perc99 485.258ms. Total count 11986
```