### PR TITLE
fix issue: service-api failed to run on gce env created by test-setup.sh

### DIFF
--- a/hack/test-config.sh
+++ b/hack/test-config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # gcloud multiplexing for shared GCE/GKE tests.
-GRS_ROOT=$(dirname "${BASH_SOURCE[0]}")
+GRS_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 SIM_NUM=${SIM_NUM:-2}
 CLIENT_NUM=${CLIENT_NUM:-4}

--- a/hack/test-teardown.sh
+++ b/hack/test-teardown.sh
@@ -2,11 +2,11 @@
 
 ### Only support gcloud 
 ### Please ensure gcloud is installed before run this script
-GRS_ROOT=$(dirname "${BASH_SOURCE[0]}")
+GRS_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-source "${GRS_ROOT}/test-config.sh"
+source "${GRS_ROOT}/hack/test-config.sh"
 
-echo "Tear down region simulator and clients... "
+echo "Tear down server, region simulator and clients... "
 
 function delete-image {
         local image_name="$1"
@@ -70,7 +70,7 @@ function delete-machine-image {
 #   main function
 ###############
 
-if [ "${SIM_AUTO_DELETE}" == "true" ]; then
+if [[ "${SIM_AUTO_DELETE}" == "true" && ${SIM_NUM} -gt 0 ]]; then
         echo "Deleting simulator resources"
         IFS=','; INSTANCE_SIM_ZONE=($SIM_ZONE); unset IFS;
         if [ ${#INSTANCE_SIM_ZONE[@]} == 1 ]; then
@@ -90,7 +90,7 @@ if [ "${SIM_AUTO_DELETE}" == "true" ]; then
         fi
 fi
 
-if [ "${CLIENT_AUTO_DELETE}" == "true" ]; then
+if [[ "${CLIENT_AUTO_DELETE}" == "true"  && ${CLIENT_NUM} -gt 0 ]]; then
         echo "Deleting client scheduler resources"
         IFS=','; INSTANCE_CLIENT_ZONE=($CLIENT_ZONE); unset IFS;
         if [ ${#INSTANCE_CLIENT_ZONE[@]} == 1 ]; then
@@ -110,7 +110,7 @@ if [ "${CLIENT_AUTO_DELETE}" == "true" ]; then
         fi
 fi
 
-if [ "${SERVER_AUTO_DELETE}" == "true" ]; then
+if [[ "${SERVER_AUTO_DELETE}" == "true"  && ${SERVER_NUM} -gt 0 ]]; then
         echo "Deleting server resources"
         IFS=','; INSTANCE_SERVER_ZONE=($SERVER_ZONE); unset IFS;
         if [ ${#INSTANCE_SERVER_ZONE[@]} == 1 ]; then


### PR DESCRIPTION
fix issue: #97 

and also fix another small error: fix ip_dissplay error when resource num==0

verified on gce with  the scenarios below, both  can start service successfully:
1. 1 server instance and 2 simulator instance, server instance created by managed instance group
2. 2 server instance and 2 simulator instance, servers created by individual vm instances.