### PR TITLE
increase node limits per client to 50k

### DIFF
--- a/resource-management/pkg/common-lib/types/clients.go
+++ b/resource-management/pkg/common-lib/types/clients.go
@@ -2,7 +2,7 @@ package types
 
 const (
 	// Max and Min request per client request during registration or update resources
-	MaxTotalMachinesPerRequest = 25000
+	MaxTotalMachinesPerRequest = 50000
 	MinTotalMachinesPerRequest = 1000
 )
 


### PR DESCRIPTION
```
I0726 23:18:43.799124   13075 stats.go:39] ListDuration: 799.774891ms. Number of nodes listed: 50080
I0726 23:18:43.799130   13075 stats.go:56] Watch session last: 30m0.000344611s
I0726 23:18:43.799134   13075 stats.go:57] Number of nodes Added: 0
I0726 23:18:43.799138   13075 stats.go:58] Number of nodes Updated: 58235
I0726 23:18:43.799142   13075 stats.go:59] Number of nodes Deleted: 0
I0726 23:18:43.799146   13075 stats.go:60] Number of nodes watch prolonged than 1s: 0
```