### PR TITLE
Add resource region simulator 'Daily' data pattern

### DIFF
--- a/resource-management/test/resourceRegionMgrSimulator/app/simulator.go
+++ b/resource-management/test/resourceRegionMgrSimulator/app/simulator.go
@@ -14,10 +14,12 @@ import (
 )
 
 type RegionConfig struct {
-	RegionName string
-	RpNum      int
-	NodesPerRP int
-	MasterPort string
+	RegionName            string
+	RpNum                 int
+	NodesPerRP            int
+	MasterPort            string
+	DataPattern           string
+	WaitTimeForMakeRpDown int
 }
 
 func Run(c *RegionConfig) error {

--- a/resource-management/test/resourceRegionMgrSimulator/main.go
+++ b/resource-management/test/resourceRegionMgrSimulator/main.go
@@ -22,6 +22,8 @@ func main() {
 	flag.IntVar(&c.RpNum, "rp_num", 10, "The number of RPs per region, if not set, default to 10")
 	flag.IntVar(&c.NodesPerRP, "nodes_per_rp", 25000, "The number of RPs per region, if not set, default to 25000")
 	flag.StringVar(&c.MasterPort, "master_port", "9119", "Service port, if not set, default to 9119")
+	flag.StringVar(&c.DataPattern, "data_pattern", "Outage", "Simulator data pattern, if not set, default to Outage Mode")
+	flag.IntVar(&c.WaitTimeForMakeRpDown, "wait_time_for_make_rp_down", 5, "Wait time for make rp down, if not set, default to 5")
 
 	if !flag.Parsed() {
 		klog.InitFlags(nil)
@@ -36,20 +38,24 @@ func main() {
 	klog.Infof("Region resource manager simulator config / region name:    (No.%v)", c.RegionName)
 	klog.Infof("Region resource manager simulator config / rp number per region: (%v)", c.RpNum)
 	klog.Infof("Region resource manager simulator config / node number per rp:  (%v)", c.NodesPerRP)
+	klog.Infof("Region resource manager simulator config / simulator data pattern:  (%v)", c.DataPattern)
+	klog.Infof("Region resource manager simulator config / wait time for make rp down:  (%v)", c.WaitTimeForMakeRpDown)
+
 	klog.Info("")
 	klog.Infof("Starting resource region manager simulator (%v)", c.RegionName)
 	klog.Info("")
 
 	// Initialize Added Event List and Modified Event List
 	// Region node Added Event List - for initpull
+	//data.Init(c.RegionName, c.DataPattern, c.RpNum, c.NodesPerRP)
 	data.Init(c.RegionName, c.RpNum, c.NodesPerRP)
 
-	// Generate update changes
-	// at ~2 min time, 5k changes
-	// at ~5 min mark, 25k changes
-	// at ~7 minutes: 1k changes.
-	// -- repeat
-	data.MakeDataUpdate()
+	// Generate update changes of Default Pattern
+	// - simulate random RP down
+	// OR
+	// Generate update changes of Daily Pattern
+	// - simulate 10 changes each minute
+	data.MakeDataUpdate(c.DataPattern, c.WaitTimeForMakeRpDown)
 
 	// Run simulater RSET API server
 	if err := app.Run(c); err != nil {
@@ -62,7 +68,7 @@ func main() {
 // function to print the usage info for the resource management api server
 func printUsage() {
 	fmt.Println("\nUsage: Region Resource Manager Simulator")
-	fmt.Println("\n       Per region config options: --region_name=<region name>  --rp_num=<number of rp>  --nodes_per_rp=<number of nodes> --master_port=<port>")
+	fmt.Println("\n       Per region config options: --region_name=<region name>  --rp_num=<number of rp>  --nodes_per_rp=<number of nodes> --master_port=<port> --data_pattern=<outage or daily> --wait_time_for_make_rp_down=<number of minutes>")
 	fmt.Println()
 
 	os.Exit(0)


### PR DESCRIPTION
This PR is to add resource region simulator 'Daily' data pattern - create 10 data changes per minute after original resource region simulator 'Outage' data pattern.

// 10 failure per simulator( region ) per minute
// 5 simulators so 50 per minute
// 1500 failure in 30 minutes

Also change to use function 'makeOneRpDown to simulate 'Outage' data pattern.

Test "outage" example:

--- service_api:
```
ubuntu@ip-172-31-8-82:~/go/src/global-resource-service$ /usr/local/go/bin/go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-34-214-160-3.us-west-2.compute.amazonaws.com --resource_urls=ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9119,ec2-34-220-203-225.us-west-2.compute.amazonaws.com:9119,ec2-54-218-112-221.us-west-2.compute.amazonaws.com:9119,ec2-18-236-222-180.us-west-2.compute.amazonaws.com:9119,ec2-34-221-5-64.us-west-2.compute.amazonaws.com:9119 --enable_metrics=true -v=3 > ~/TMP/service.log.2022-07-28.v000064 2>&1 &
```

--- 5 simulators:
```
ubuntu@ip-172-31-8-205:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=20000 --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=1 -v=3 > ~/TMP/simulator.1.log.2022-07-28.v000064 2>&1 &

ubuntu@ip-172-31-0-210:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Wulan --rp_num=10 --nodes_per_rp=20000  --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=3 -v=3 > ~/TMP/simulator.2.log.2022-07-28.v000064 2>&1 &

ubuntu@ip-172-31-0-210:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Wulan --rp_num=10 --nodes_per_rp=20000  --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=3 -v=3 > ~/TMP/simulator.3.log.2022-07-28.v000064 2>&1 &

ubuntu@ip-172-31-14-82:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Guizhou --rp_num=10 --nodes_per_rp=20000  --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=4 -v=3 > ~/TMP/simulator.4.log.2022-07-28.v000064 2>&1 &

ubuntu@ip-172-31-0-203:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Reserved1 --rp_num=10 --nodes_per_rp=20000  --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=5 -v=3 > ~/TMP/simulator.5.log.2022-07-28.v000064 2>&1 &
```

41 schedulers:
```
ubuntu@ip-172-31-4-135:~/go/src/global-resource-service$ for i in {1..14}; do sleep 1; go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-34-214-160-3.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 -v=3 > ~/TMP/scheduler.6.$i.log.2022-07-28.v000064 2>&1 & done

ubuntu@ip-172-31-1-189:~/go/src/global-resource-service$ for i in {1..14}; do sleep 1;   go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-34-214-160-3.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 -v=3 > ~/TMP/scheduler.8.$i.log.2022-07-28.v000064 2>&1 & done

ubuntu@ip-172-31-17-152:~/go/src/global-resource-service$ for i in {1..13}; do sleep 1;  go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-34-214-160-3.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 -v=3 > ~/TMP/scheduler.7.$i.log.2022-07-28.v000064 2>&1 & done

```

Test "Daily" example:
--- service_api:
```
ubuntu@ip-172-31-8-82:~/go/src/global-resource-service$ /usr/local/go/bin/go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-34-214-160-3.us-west-2.compute.amazonaws.com --resource_urls=ec2-52-24-162-197.us-west-2.compute.amazonaws.com:9119,ec2-34-220-203-225.us-west-2.compute.amazonaws.com:9119,ec2-54-218-112-221.us-west-2.compute.amazonaws.com:9119,ec2-18-236-222-180.us-west-2.compute.amazonaws.com:9119,ec2-34-221-5-64.us-west-2.compute.amazonaws.com:9119 --enable_metrics=true -v=3 > ~/TMP/service.log.2022-07-28.v000065 2>&1 &
```

--- 5 simulators:
```
ubuntu@ip-172-31-8-205:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=20000 --master_port=9119 --data_pattern=Daily  -v=3 > ~/TMP/simulator.1.log.2022-07-28.v000065 2>&1 &

ubuntu@ip-172-31-0-210:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Wulan --rp_num=10 --nodes_per_rp=20000  --master_port=9119 --data_pattern=Daily -v=3 > ~/TMP/simulator.2.log.2022-07-28.v000065 2>&1 &

ubuntu@ip-172-31-0-210:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Wulan --rp_num=10 --nodes_per_rp=20000  --master_port=9119 --data_pattern=Daily -v=3 > ~/TMP/simulator.3.log.2022-07-28.v000065 2>&1 &

ubuntu@ip-172-31-14-82:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Guizhou --rp_num=10 --nodes_per_rp=20000  --master_port=9119 --data_pattern=Daily  -v=3 > ~/TMP/simulator.4.log.2022-07-28.v000065 2>&1 &

ubuntu@ip-172-31-0-203:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Reserved1 --rp_num=10 --nodes_per_rp=20000  --master_port=9119 --data_pattern=Daily -v=3 > ~/TMP/simulator.5.log.2022-07-28.v000065 2>&1 &
```

41 schedulers:
```
ubuntu@ip-172-31-4-135:~/go/src/global-resource-service$ for i in {1..14}; do sleep 1; go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-34-214-160-3.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 -v=3 > ~/TMP/scheduler.6.$i.log.2022-07-28.v000065 2>&1 & done

ubuntu@ip-172-31-1-189:~/go/src/global-resource-service$ for i in {1..14}; do sleep 1;   go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-34-214-160-3.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 -v=3 > ~/TMP/scheduler.8.$i.log.2022-07-28.v000065 2>&1 & done

ubuntu@ip-172-31-17-152:~/go/src/global-resource-service$ for i in {1..13}; do sleep 1;  go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-34-214-160-3.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 -v=3 > ~/TMP/scheduler.7.$i.log.2022-07-28.v000065 2>&1 & done

```


