### PR TITLE
Delay 2 hours when simulate one RP down for one region in resource region simulator

### DIFF
--- a/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
@@ -52,8 +52,10 @@ func MakeDataUpdate(data_pattern string, wait_time_for_make_rp_down int) {
 				// Generate one RP down event during specfied interval
 				time.Sleep(time.Duration(wait_time_for_make_rp_down) * time.Minute)
 				makeOneRPDown()
-
 				klog.V(3).Info("Generating one RP down event is completed")
+
+				time.Sleep(120 * time.Minute)
+				klog.V(6).Info("Simulate to delay 2 hours")
 			}
 		case "Daily":
 			for {


### PR DESCRIPTION
This PR is to sleep 2 hours when simulate one RP down for one region in resource region simulator for testing.