### PR TITLE
[BugFix] #104 - simulator: panic: invalid argument to Intn

### DIFF
--- a/resource-management/test/resourceRegionMgrSimulator/main.go
+++ b/resource-management/test/resourceRegionMgrSimulator/main.go
@@ -32,20 +32,17 @@ func main() {
 
 	// Input parameter error handling for c.RpNum and c.NodesPerRP
 	// Fix bug #104
-	if c.RpNum < 1 || c.NodesPerRP < 1 {
-		klog.Info("")
-
-		if c.RpNum < 1 {
-			klog.Errorf("Error: Region resource manager simulator config / rp number per region:  (%v) is less than 1", c.RpNum)
-		}
-
-		if c.NodesPerRP < 1 {
-			klog.Errorf("Error: Region resource manager simulator config / node number per rp:  (%v) is less than 1", c.NodesPerRP)
-		}
-
-		klog.Info("")
+	klog.Info("")
+	if c.RpNum < 1 {
+		klog.Errorf("Error: Region resource manager simulator config / rp number per region:  (%v) is less than 1", c.RpNum)
 		os.Exit(1)
 	}
+
+	if c.NodesPerRP < 1 {
+		klog.Errorf("Error: Region resource manager simulator config / node number per rp:  (%v) is less than 1", c.NodesPerRP)
+		os.Exit(1)
+	}
+	klog.Info("")
 
 	// Keep a more frequent flush frequency as 1 second
 	klog.StartFlushDaemon(time.Second * 1)


### PR DESCRIPTION
This PR is to simply fix the bug #104 by adding the check to ensure input command line parameters for Nodes Per RP or RP Number Per Region is greater than 0.