### PR TITLE
add copyright tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ then the robot will assign the issue to you and your name will present at `Assig
 While we encourage everyone to contribute code, it is also appreciated when someone reports an issue.
 Issues should be filed under the appropriate CentaurusInfra sub-repository.
 
-*Example:* An globle-resource-service issue should be opened to [Global-Resource-Service](https://github.com/CentaurusInfra/global-resource-service). 
+*Example:* A global-resource-service issue should be opened to [Global-Resource-Service](https://github.com/CentaurusInfra/global-resource-service). 
 
 Please follow the prompted submission guidelines while opening an issue.
 

--- a/hack/copyright/config.sh
+++ b/hack/copyright/config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2022 Authors of Globle Resource Service.
+# Copyright 2022 Authors of Global Resource Service.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ GRS_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
 
 COPYRIGHT_MATCH=${COPYRIGHT_MATCH:-"limitations under the License"}
 COPYRIGHT_YEAR=${COPYRIGHT_YEAR:-"$( date +%Y )"}
-GRS_COPYRIGHT_LINE_MODIFIED_GO=${GRS_COPYRIGHT_LINE_MODIFIED_GO:-"Copyright ${COPYRIGHT_YEAR} Authors of Globle Resource Service - file modified."}
-GRS_COPYRIGHT_LINE_MODIFIED_OTHER=${GRS_COPYRIGHT_LINE_MODIFIED_OTHER:-"# Copyright ${COPYRIGHT_YEAR} Authors of Globle Resource Service - file modified."}
+GRS_COPYRIGHT_LINE_MODIFIED_GO=${GRS_COPYRIGHT_LINE_MODIFIED_GO:-"Copyright ${COPYRIGHT_YEAR} Authors of Global Resource Service - file modified."}
+GRS_COPYRIGHT_LINE_MODIFIED_OTHER=${GRS_COPYRIGHT_LINE_MODIFIED_OTHER:-"# Copyright ${COPYRIGHT_YEAR} Authors of Global Resource Service - file modified."}
 K8S_COPYRIGHT_MATCH=${K8S_COPYRIGHT_MATCH:-"The Kubernetes Authors"}
-GRS_COPYRIGHT_MATCH=${GRS_COPYRIGHT_MATCH:-"Authors of Globle Resource Service"}
-GRS_COPYRIGHT_LINE_NEW_GO="/*\nCopyright ${COPYRIGHT_YEAR} Authors of Globle Resource Service.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n*/\n"
-GRS_COPYRIGHT_LINE_NEW_OTHER="#\n# Copyright ${COPYRIGHT_YEAR} Authors of Globle Resource Service.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n"
+GRS_COPYRIGHT_MATCH=${GRS_COPYRIGHT_MATCH:-"Authors of Global Resource Service"}
+GRS_COPYRIGHT_LINE_NEW_GO="/*\nCopyright ${COPYRIGHT_YEAR} Authors of Global Resource Service.\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n*/\n"
+GRS_COPYRIGHT_LINE_NEW_OTHER="#\n# Copyright ${COPYRIGHT_YEAR} Authors of Global Resource Service.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n"
 
 
 #DAY0_COMMIT=$( git rev-list --max-parents=0 HEAD | tail -n 1 )

--- a/hack/copyright/grs-copyright.sh
+++ b/hack/copyright/grs-copyright.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2022 Authors of Globle Resource Service.
+# Copyright 2022 Authors of Global Resource Service.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ fi
 
 display_usage() {
     echo "Usage: $0 <optional-grs-repo-path> <optional-log-directory>"
-    echo "       If optional globle-resource-service repo path is provided, repo setup step will be skipped"
+    echo "       If optional global-resource-service repo path is provided, repo setup step will be skipped"
 }
 
 if [ ! -z $2 ]


### PR DESCRIPTION
Copyright tools: ./hack/copyright/grs-copyright.sh is based on git difference. By default, START_COMMIT is equal to current merged commit (CentaurusInfra), HEAD_COMMIT is the last commit on your local dev machine. if you want to check copyright started from specific commit, you can set  START_COMMIT. for example, the command below will check all files from repo day0:
```
START_COMMIT=`git rev-list --max-parents=0 HEAD | tail -n 1`
./hack/copyright/grs-copyright.sh
```

