### PR TITLE
[BugFix] #103 - Service_api.go triggers aggregator error: Get "http:///resources/initpull": http: no Host in request URL

### DIFF
--- a/resource-management/cmds/service-api/service-api.go
+++ b/resource-management/cmds/service-api/service-api.go
@@ -3,10 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"k8s.io/klog/v2"
 	"os"
 	"strings"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	"global-resource-service/resource-management/cmds/service-api/app"
 	localMetrics "global-resource-service/resource-management/pkg/common-lib/metrics"
@@ -36,8 +37,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Trim any leading or trailing "," seperators
+	// Fix bug #103
+	urls = strings.TrimLeft(urls, ",")
+	urls = strings.TrimRight(urls, ",")
+
 	localMetrics.SetEnableResourceManagementMeasurement(metricsEnabled)
 	c.ResourceUrls = strings.Split(urls, ",")
+
+	// Check whether c.ResourceUrls contains invaild urls
+	for _, url := range c.ResourceUrls {
+		if url == "" {
+			klog.Errorf("Error: resource url is missing or wrong input when input --resource_urls")
+			os.Exit(1)
+		}
+	}
 
 	// keep a more frequent flush frequency as 1 second
 	klog.StartFlushDaemon(time.Second * 1)


### PR DESCRIPTION
This PR is to fix the bug reported by issue #103.

The codes have been tested by 1 service api machine plus 3 simulator machines on AWS.