### PR TITLE
[BugFix] #55 - Fix redis store UT test issue

### DIFF
--- a/resource-management/pkg/store/redis/redis.go
+++ b/resource-management/pkg/store/redis/redis.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -50,6 +51,11 @@ func NewRedisClient() *Goredis {
 	})
 
 	ctx := context.Background()
+
+	if err := client.FlushAll(ctx).Err(); err != nil {
+		klog.Errorf("Flush all dbs in error : (%v)", err)
+		os.Exit(1)
+	}
 
 	return &Goredis{
 		client: client,


### PR DESCRIPTION
This PR is to fix the bug reported by issue #55 and ensure to flush all existing DB prior to Unit Test.

The codes have been tested on 1 service_api machine and 3 simulator machines on AWS.

1.  start 1 service api and 3 simulators, write 60000 nodes, check redis store in first time
```
127.0.0.1:6379> info keyspace
# Keyspace
db0:keys=60001,expires=0,avg_ttl=0
```

2.  Run redis unit test without errors.
```
ubuntu@ip-172-31-8-82:~/go/src/global-resource-service/resource-management/pkg/store/redis$ go test
PASS
ok      global-resource-service/resource-management/pkg/store/redis     0.052s

```
3.  Check redis store in second time and original 60001 keys are removed and new 4 test keys are written successfully
```
127.0.0.1:6379> info keyspace
# Keyspace
db0:keys=4,expires=0,avg_ttl=0
127.0.0.1:6379> KEYS *
1) "testkey1NM"
2) "VirtualNodesAssignments"
3) "NodeStoreStatus"
4) "MinNode.0001.1000.1000"
```

