### PR TITLE
balance scheduler service number when start scheduler

### DIFF
--- a/hack/test-rune2e.sh
+++ b/hack/test-rune2e.sh
@@ -174,7 +174,7 @@ if [ ${CLIENT_NUM} -gt 0 ]; then
                         --format='value(instance)'))
 
                         index=0
-                        service_num=$((${SCHEDULER_NUM} / ${CLIENT_NUM} + 1))
+                        service_num=$(((${SCHEDULER_NUM} + 1) / ${CLIENT_NUM}))
                         for name in "${instance_names[@]}"; do
                                 if [ $index == $((${CLIENT_NUM} - 1)) ]; then
                                         done_num=$((${service_num} * ${index} ))
@@ -185,7 +185,7 @@ if [ ${CLIENT_NUM} -gt 0 ]; then
                         done
                 else
                         index=0
-                        service_num=$((${SCHEDULER_NUM} / ${CLIENT_NUM} + 1))
+                        service_num=$(((${SCHEDULER_NUM} + 1) / ${CLIENT_NUM}))
                         for zone in "${INSTANCE_CLIENT_ZONE[@]}"; do
                                 if [ $index == $((${CLIENT_NUM} - 1)) ]; then
                                         done_num=$((${service_num} * ${index} ))


### PR DESCRIPTION
Part of issue: #120. after this fix, scheduler has balanced number of service on each machine, but the RegisterClientDuration still have big difference:


file name | RegisterClientDuration
-- | --
grs-down-dismt-client-us-central1-a-mig-f361.log.0 | 365.287036ms
grs-down-dismt-client-us-central1-a-mig-f361.log.1 | 521.043594ms
grs-down-dismt-client-us-central1-a-mig-f361.log.2 | 342.378137ms
grs-down-dismt-client-us-central1-a-mig-f361.log.3 | 368.195141ms
grs-down-dismt-client-us-central1-a-mig-f361.log.4 | 360.4061ms
grs-down-dismt-client-us-central1-a-mig-f361.log.5 | 315.15387ms
grs-down-dismt-client-us-central1-a-mig-f361.log.6 | 320.079994ms
grs-down-dismt-client-us-central1-a-mig-f361.log.7 | 320.47048ms
grs-down-dismt-client-us-central1-a-mig-f361.log.8 | 374.838644ms
grs-down-dismt-client-us-central1-a-mig-f361.log.9 | 313.702576ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.0 | 5.46519ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.1 | 6.91962ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.2 | 6.453254ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.3 | 5.610316ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.4 | 5.197985ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.5 | 5.04598ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.6 | 5.100392ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.7 | 5.334791ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.8 | 5.047824ms
grs-down-dismt-client-us-central1-a-mig-z8mf.log.9 | 5.13324ms

