### PR TITLE
Improvement for aggregator and simulator of Outage pattern

### DIFF
--- a/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents_test.go
+++ b/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents_test.go
@@ -53,13 +53,13 @@ func TestGetRegionNodeModifiedEventsCRV(t *testing.T) {
 	// 29.219756ms -> 4.096µs
 	duration = time.Since(start)
 	assert.NotNil(t, modifiedEvents)
-	assert.Equal(t, 10, len(modifiedEvents))
-	t.Logf("Time to get %d update events: %v", count, duration)
+	assert.Equal(t, rpNum, len(modifiedEvents))
+	t.Logf("Time to get %d update events in Daily data pattern: %v", count, duration)
 	assert.Equal(t, uint64(atEachMin10), count)
 
 	//check remaining event list
-	assert.Equal(t, 10, len(RegionNodeUpdateEventList))
-	for i := 0; i < 10; i++ {
+	assert.Equal(t, rpNum, len(RegionNodeUpdateEventList))
+	for i := 0; i < rpNum; i++ {
 		assert.Nil(t, nil, RegionNodeUpdateEventList[i])
 	}
 
@@ -78,13 +78,39 @@ func TestGetRegionNodeModifiedEventsCRV(t *testing.T) {
 	// 3.987µs
 	duration = time.Since(start)
 	assert.NotNil(t, modifiedEvents)
-	assert.Equal(t, 10, len(modifiedEvents))
-	t.Logf("Time to get %d update events: %v", count, duration)
+	assert.Equal(t, rpNum, len(modifiedEvents))
+	t.Logf("Time to get %d update events in Daily data pattern: %v", count, duration)
 	assert.Equal(t, atEachMin10*2, int(count))
 
 	//check remaining event list
-	assert.Equal(t, 10, len(RegionNodeUpdateEventList))
-	for i := 0; i < 10; i++ {
+	assert.Equal(t, rpNum, len(RegionNodeUpdateEventList))
+	for i := 0; i < rpNum; i++ {
+		assert.Nil(t, nil, RegionNodeUpdateEventList[i])
+	}
+
+	// generate update node events of Outage pattern
+	makeOneRPDown()
+
+	// get update nodes
+	for j := 0; j < location.GetRPNum(); j++ {
+		rvLoc := types.RvLocation{
+			Region:    location.Region(RegionId),
+			Partition: location.ResourcePartition(j),
+		}
+		rvs[rvLoc] = uint64(nodesPerRP)
+	}
+	start = time.Now()
+	modifiedEvents, count = GetRegionNodeModifiedEventsCRV(rvs)
+	// 38.041491ms -> 3.929264ms on AWS EC2 instance (t2.2xlarge - 8 vcpu/32G memory)
+	duration = time.Since(start)
+	assert.NotNil(t, modifiedEvents)
+	assert.Equal(t, rpNum, len(modifiedEvents))
+	t.Logf("Time to get %d update events in Outage data pattern: %v", count, duration)
+	assert.Equal(t, uint64(nodesPerRP), count)
+
+	//check remaining event list
+	assert.Equal(t, rpNum, len(RegionNodeUpdateEventList))
+	for i := 0; i < rpNum; i++ {
 		assert.Nil(t, nil, RegionNodeUpdateEventList[i])
 	}
 }


### PR DESCRIPTION
This PR is to provide the following 2 performance improvements:
 - aggregator pull interval from 10ms to possible less than 10ms
 - simulator for outage pattern based on daily pattern.

The code changes have been tested without issue in 500k nodes under 2 regions / 10RPs / 25K nodes per RP/20 schedulers/25k   nodes per scheduler for Outage pattern and daily pattern on AWS test environment.

Last integration test was successful on 2022-08-26.

UT test for newest codes of Outage data pattern on AWS EC2 instance (t2.2xlarge - 8vcpu/32G memory):
```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/test/resourceRegionMgrSimulator/data$ go test -v
=== RUN   TestGetRegionNodeModifiedEventsCRV
    regionNodeEvents_test.go:37: Time to generate 500000 init events: 2.318053552s
    regionNodeEvents_test.go:57: Time to get 10 update events in Daily data pattern: 5.891µs
    regionNodeEvents_test.go:82: Time to get 20 update events in Daily data pattern: 9.301µs
    regionNodeEvents_test.go:108: Time to get 50000 update events in Outage data pattern: 3.966044ms
--- PASS: TestGetRegionNodeModifiedEventsCRV (2.40s)
PASS
ok      global-resource-service/resource-management/test/resourceRegionMgrSimulator/data        2.437s
```

UT test for the old codes of Outage data pattern prior to PR139 on AWS EC2 instance (t2.2xlarge - 8vcpu/32G memory) :
```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/test/resourceRegionMgrSimulator/data$ go test -v
=== RUN   TestGetRegionNodeModifiedEventsCRV
    regionNodeEvents_test.go:37: Time to generate 500000 init events: 2.287078622s
    regionNodeEvents_test.go:128: Time to get 50000 update events in Outage data pattern: 38.041491ms
--- PASS: TestGetRegionNodeModifiedEventsCRV (2.41s)
PASS
ok      global-resource-service/resource-management/test/resourceRegionMgrSimulator/data        2.439s
```

Integration test comparation between new codes today and old codes on 2022-08-10 for 500K nodes / 2 regions /20 schedulers for outage pattern

2022-08-25:
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ /usr/local/go/bin/go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-52-11-1-193.us-west-2.compute.amazonaws.com --resource_urls=ec2-54-187-22-27.us-west-2.compute.amazonaws.com:9119,ec2-35-91-52-72.us-west-2.compute.amazonaws.com:9119 --enable_metrics=false -v=3  > ~/TMP/service.log.2022-08-25.v000153 2>&1 &

ubuntu@ip-172-31-8-205:~/go/src/GRS$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=2 -v=3  > ~/TMP/simulator1.log.2022-08-25.v000153 2>&1 &
ubuntu@ip-172-31-7-9:~/go/src/GRS$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Shanghai --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=5 -v=3 > ~/TMP/simulator2.log.2022-08-25.v000153 2>&1 &

ubuntu@ip-172-31-1-189:~/go/src/GRS$ for i in {1..20}; do sleep 1;   go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-52-11-1-193.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 --request_timeout=6m -v=3 > ~/TMP/scheduler.8.$i.log.2022-08-25.v000153 2>&1 & done


/home/ubuntu/TMP/scheduler.8.1.log.2022-08-25.v000154:I0825 23:02:26.915916  160443 stats.go:44] [Metrics][Register]RegisterClientDuration: 19.890306ms
/home/ubuntu/TMP/scheduler.8.1.log.2022-08-25.v000154:I0825 23:02:26.915935  160443 stats.go:57] [Metrics][List]ListDuration: 613.137297ms. Number of nodes listed: 25025
/home/ubuntu/TMP/scheduler.8.1.log.2022-08-25.v000154:I0825 23:02:26.915947  160443 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000861845s. Number of nodes Added :0, Updated: 2800, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.1.log.2022-08-25.v000154:I0825 23:02:26.916243  160443 stats.go:81] [Metrics][Watch] perc50 576.603027ms, perc90 585.880015ms, perc99 587.975996ms. Total count 2800
/home/ubuntu/TMP/scheduler.8.10.log.2022-08-25.v000154:I0825 23:02:35.673148  161393 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.010588ms
/home/ubuntu/TMP/scheduler.8.10.log.2022-08-25.v000154:I0825 23:02:35.673167  161393 stats.go:57] [Metrics][List]ListDuration: 611.002144ms. Number of nodes listed: 25018
/home/ubuntu/TMP/scheduler.8.10.log.2022-08-25.v000154:I0825 23:02:35.673177  161393 stats.go:76] [Metrics][Watch]Watch session last: 7m0.001315849s. Number of nodes Added :0, Updated: 2637, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.10.log.2022-08-25.v000154:I0825 23:02:35.673468  161393 stats.go:81] [Metrics][Watch] perc50 582.035376ms, perc90 591.123298ms, perc99 592.664985ms. Total count 2637
/home/ubuntu/TMP/scheduler.8.11.log.2022-08-25.v000154:I0825 23:02:36.658111  161495 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.042072ms
/home/ubuntu/TMP/scheduler.8.11.log.2022-08-25.v000154:I0825 23:02:36.658130  161495 stats.go:57] [Metrics][List]ListDuration: 596.199011ms. Number of nodes listed: 25000
/home/ubuntu/TMP/scheduler.8.11.log.2022-08-25.v000154:I0825 23:02:36.658140  161495 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000745061s. Number of nodes Added :0, Updated: 2103, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.11.log.2022-08-25.v000154:I0825 23:02:36.658356  161495 stats.go:81] [Metrics][Watch] perc50 569.020404ms, perc90 574.615438ms, perc99 579.181675ms. Total count 2103
/home/ubuntu/TMP/scheduler.8.12.log.2022-08-25.v000154:I0825 23:02:37.667891  161601 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.215814ms
/home/ubuntu/TMP/scheduler.8.12.log.2022-08-25.v000154:I0825 23:02:37.667909  161601 stats.go:57] [Metrics][List]ListDuration: 611.03755ms. Number of nodes listed: 25016
/home/ubuntu/TMP/scheduler.8.12.log.2022-08-25.v000154:I0825 23:02:37.667962  161601 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000497293s. Number of nodes Added :0, Updated: 2549, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.12.log.2022-08-25.v000154:I0825 23:02:37.668322  161601 stats.go:81] [Metrics][Watch] perc50 569.797331ms, perc90 577.524453ms, perc99 581.619616ms. Total count 2549
/home/ubuntu/TMP/scheduler.8.13.log.2022-08-25.v000154:I0825 23:02:38.686606  161712 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.764799ms
/home/ubuntu/TMP/scheduler.8.13.log.2022-08-25.v000154:I0825 23:02:38.686626  161712 stats.go:57] [Metrics][List]ListDuration: 622.919175ms. Number of nodes listed: 25000
/home/ubuntu/TMP/scheduler.8.13.log.2022-08-25.v000154:I0825 23:02:38.686636  161712 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000507001s. Number of nodes Added :0, Updated: 2760, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.13.log.2022-08-25.v000154:I0825 23:02:38.686951  161712 stats.go:81] [Metrics][Watch] perc50 576.72057ms, perc90 581.114702ms, perc99 583.614188ms. Total count 2760
/home/ubuntu/TMP/scheduler.8.14.log.2022-08-25.v000154:I0825 23:02:39.686397  161816 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.083628ms
/home/ubuntu/TMP/scheduler.8.14.log.2022-08-25.v000154:I0825 23:02:39.686417  161816 stats.go:57] [Metrics][List]ListDuration: 618.695348ms. Number of nodes listed: 25007
/home/ubuntu/TMP/scheduler.8.14.log.2022-08-25.v000154:I0825 23:02:39.686427  161816 stats.go:76] [Metrics][Watch]Watch session last: 7m0.001540718s. Number of nodes Added :0, Updated: 2394, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.14.log.2022-08-25.v000154:I0825 23:02:39.686686  161816 stats.go:81] [Metrics][Watch] perc50 580.725047ms, perc90 598.320332ms, perc99 599.798384ms. Total count 2394
/home/ubuntu/TMP/scheduler.8.15.log.2022-08-25.v000154:I0825 23:02:40.671540  161924 stats.go:44] [Metrics][Register]RegisterClientDuration: 16.709115ms
/home/ubuntu/TMP/scheduler.8.15.log.2022-08-25.v000154:I0825 23:02:40.671565  161924 stats.go:57] [Metrics][List]ListDuration: 607.675965ms. Number of nodes listed: 25009
/home/ubuntu/TMP/scheduler.8.15.log.2022-08-25.v000154:I0825 23:02:40.671576  161924 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000823415s. Number of nodes Added :0, Updated: 2636, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.15.log.2022-08-25.v000154:I0825 23:02:40.671865  161924 stats.go:81] [Metrics][Watch] perc50 595.792605ms, perc90 604.467905ms, perc99 606.503446ms. Total count 2636
/home/ubuntu/TMP/scheduler.8.16.log.2022-08-25.v000154:I0825 23:02:41.635313  162032 stats.go:44] [Metrics][Register]RegisterClientDuration: 16.819404ms
/home/ubuntu/TMP/scheduler.8.16.log.2022-08-25.v000154:I0825 23:02:41.635331  162032 stats.go:57] [Metrics][List]ListDuration: 576.955888ms. Number of nodes listed: 25016
/home/ubuntu/TMP/scheduler.8.16.log.2022-08-25.v000154:I0825 23:02:41.635340  162032 stats.go:76] [Metrics][Watch]Watch session last: 7m0.00064319s. Number of nodes Added :0, Updated: 2472, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.16.log.2022-08-25.v000154:I0825 23:02:41.635618  162032 stats.go:81] [Metrics][Watch] perc50 574.714312ms, perc90 585.432047ms, perc99 587.958734ms. Total count 2472
/home/ubuntu/TMP/scheduler.8.17.log.2022-08-25.v000154:I0825 23:02:42.663837  162139 stats.go:44] [Metrics][Register]RegisterClientDuration: 16.66477ms
/home/ubuntu/TMP/scheduler.8.17.log.2022-08-25.v000154:I0825 23:02:42.663853  162139 stats.go:57] [Metrics][List]ListDuration: 601.169888ms. Number of nodes listed: 25017
/home/ubuntu/TMP/scheduler.8.17.log.2022-08-25.v000154:I0825 23:02:42.663862  162139 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000469744s. Number of nodes Added :0, Updated: 2403, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.17.log.2022-08-25.v000154:I0825 23:02:42.664107  162139 stats.go:81] [Metrics][Watch] perc50 581.062679ms, perc90 606.266509ms, perc99 608.350185ms. Total count 2403
/home/ubuntu/TMP/scheduler.8.18.log.2022-08-25.v000154:I0825 23:02:43.693494  162247 stats.go:44] [Metrics][Register]RegisterClientDuration: 16.111883ms
/home/ubuntu/TMP/scheduler.8.18.log.2022-08-25.v000154:I0825 23:02:43.693512  162247 stats.go:57] [Metrics][List]ListDuration: 621.00163ms. Number of nodes listed: 25009
/home/ubuntu/TMP/scheduler.8.18.log.2022-08-25.v000154:I0825 23:02:43.693521  162247 stats.go:76] [Metrics][Watch]Watch session last: 7m0.001411876s. Number of nodes Added :0, Updated: 2670, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.18.log.2022-08-25.v000154:I0825 23:02:43.693819  162247 stats.go:81] [Metrics][Watch] perc50 597.740017ms, perc90 602.22701ms, perc99 603.933481ms. Total count 2670
/home/ubuntu/TMP/scheduler.8.19.log.2022-08-25.v000154:I0825 23:02:44.662103  162352 stats.go:44] [Metrics][Register]RegisterClientDuration: 16.060539ms
/home/ubuntu/TMP/scheduler.8.19.log.2022-08-25.v000154:I0825 23:02:44.662121  162352 stats.go:57] [Metrics][List]ListDuration: 589.146245ms. Number of nodes listed: 25022
/home/ubuntu/TMP/scheduler.8.19.log.2022-08-25.v000154:I0825 23:02:44.662131  162352 stats.go:76] [Metrics][Watch]Watch session last: 7m0.001096954s. Number of nodes Added :0, Updated: 2496, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.19.log.2022-08-25.v000154:I0825 23:02:44.662396  162352 stats.go:81] [Metrics][Watch] perc50 582.60957ms, perc90 615.806315ms, perc99 618.291245ms. Total count 2496
/home/ubuntu/TMP/scheduler.8.2.log.2022-08-25.v000154:I0825 23:02:27.678100  160547 stats.go:44] [Metrics][Register]RegisterClientDuration: 18.222984ms
/home/ubuntu/TMP/scheduler.8.2.log.2022-08-25.v000154:I0825 23:02:27.678118  160547 stats.go:57] [Metrics][List]ListDuration: 617.320323ms. Number of nodes listed: 25010
/home/ubuntu/TMP/scheduler.8.2.log.2022-08-25.v000154:I0825 23:02:27.678128  160547 stats.go:76] [Metrics][Watch]Watch session last: 7m0.001166573s. Number of nodes Added :0, Updated: 2514, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.2.log.2022-08-25.v000154:I0825 23:02:27.678388  160547 stats.go:81] [Metrics][Watch] perc50 578.680855ms, perc90 587.533557ms, perc99 589.169766ms. Total count 2514
/home/ubuntu/TMP/scheduler.8.3.log.2022-08-25.v000154:I0825 23:02:28.657012  160643 stats.go:44] [Metrics][Register]RegisterClientDuration: 18.347269ms
/home/ubuntu/TMP/scheduler.8.3.log.2022-08-25.v000154:I0825 23:02:28.657031  160643 stats.go:57] [Metrics][List]ListDuration: 608.266972ms. Number of nodes listed: 25002
/home/ubuntu/TMP/scheduler.8.3.log.2022-08-25.v000154:I0825 23:02:28.657042  160643 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000918418s. Number of nodes Added :0, Updated: 2481, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.3.log.2022-08-25.v000154:I0825 23:02:28.657370  160643 stats.go:81] [Metrics][Watch] perc50 590.836902ms, perc90 595.503122ms, perc99 597.335648ms. Total count 2481
/home/ubuntu/TMP/scheduler.8.4.log.2022-08-25.v000154:I0825 23:02:29.648916  160750 stats.go:44] [Metrics][Register]RegisterClientDuration: 18.446526ms
/home/ubuntu/TMP/scheduler.8.4.log.2022-08-25.v000154:I0825 23:02:29.648936  160750 stats.go:57] [Metrics][List]ListDuration: 596.786093ms. Number of nodes listed: 25003
/home/ubuntu/TMP/scheduler.8.4.log.2022-08-25.v000154:I0825 23:02:29.648947  160750 stats.go:76] [Metrics][Watch]Watch session last: 7m0.001306815s. Number of nodes Added :0, Updated: 2198, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.4.log.2022-08-25.v000154:I0825 23:02:29.649183  160750 stats.go:81] [Metrics][Watch] perc50 570.688877ms, perc90 574.939517ms, perc99 576.057064ms. Total count 2198
/home/ubuntu/TMP/scheduler.8.5.log.2022-08-25.v000154:I0825 23:02:30.664564  160855 stats.go:44] [Metrics][Register]RegisterClientDuration: 18.02572ms
/home/ubuntu/TMP/scheduler.8.5.log.2022-08-25.v000154:I0825 23:02:30.664583  160855 stats.go:57] [Metrics][List]ListDuration: 614.928489ms. Number of nodes listed: 25015
/home/ubuntu/TMP/scheduler.8.5.log.2022-08-25.v000154:I0825 23:02:30.664594  160855 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000616684s. Number of nodes Added :0, Updated: 2032, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.5.log.2022-08-25.v000154:I0825 23:02:30.664802  160855 stats.go:81] [Metrics][Watch] perc50 570.576074ms, perc90 577.824264ms, perc99 579.631096ms. Total count 2032
/home/ubuntu/TMP/scheduler.8.6.log.2022-08-25.v000154:I0825 23:02:31.628100  160962 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.584817ms
/home/ubuntu/TMP/scheduler.8.6.log.2022-08-25.v000154:I0825 23:02:31.628117  160962 stats.go:57] [Metrics][List]ListDuration: 580.88503ms. Number of nodes listed: 25015
/home/ubuntu/TMP/scheduler.8.6.log.2022-08-25.v000154:I0825 23:02:31.628128  160962 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000521597s. Number of nodes Added :0, Updated: 2856, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.6.log.2022-08-25.v000154:I0825 23:02:31.628430  160962 stats.go:81] [Metrics][Watch] perc50 571.806939ms, perc90 592.687692ms, perc99 594.263258ms. Total count 2856
/home/ubuntu/TMP/scheduler.8.7.log.2022-08-25.v000154:I0825 23:02:32.655795  161070 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.497515ms
/home/ubuntu/TMP/scheduler.8.7.log.2022-08-25.v000154:I0825 23:02:32.655812  161070 stats.go:57] [Metrics][List]ListDuration: 604.282099ms. Number of nodes listed: 25010
/home/ubuntu/TMP/scheduler.8.7.log.2022-08-25.v000154:I0825 23:02:32.655823  161070 stats.go:76] [Metrics][Watch]Watch session last: 7m0.000594724s. Number of nodes Added :0, Updated: 2475, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.7.log.2022-08-25.v000154:I0825 23:02:32.656076  161070 stats.go:81] [Metrics][Watch] perc50 561.712254ms, perc90 576.5706ms, perc99 580.240694ms. Total count 2475
/home/ubuntu/TMP/scheduler.8.8.log.2022-08-25.v000154:I0825 23:02:33.655362  161173 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.019811ms
/home/ubuntu/TMP/scheduler.8.8.log.2022-08-25.v000154:I0825 23:02:33.655383  161173 stats.go:57] [Metrics][List]ListDuration: 598.854665ms. Number of nodes listed: 25001
/home/ubuntu/TMP/scheduler.8.8.log.2022-08-25.v000154:I0825 23:02:33.655394  161173 stats.go:76] [Metrics][Watch]Watch session last: 7m0.001402399s. Number of nodes Added :0, Updated: 2650, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.8.log.2022-08-25.v000154:I0825 23:02:33.655712  161173 stats.go:81] [Metrics][Watch] perc50 576.499218ms, perc90 591.433392ms, perc99 592.629077ms. Total count 2650
/home/ubuntu/TMP/scheduler.8.9.log.2022-08-25.v000154:I0825 23:02:34.680994  161286 stats.go:44] [Metrics][Register]RegisterClientDuration: 17.044886ms
/home/ubuntu/TMP/scheduler.8.9.log.2022-08-25.v000154:I0825 23:02:34.681013  161286 stats.go:57] [Metrics][List]ListDuration: 623.76437ms. Number of nodes listed: 25007
/home/ubuntu/TMP/scheduler.8.9.log.2022-08-25.v000154:I0825 23:02:34.681022  161286 stats.go:76] [Metrics][Watch]Watch session last: 7m0.001042758s. Number of nodes Added :0, Updated: 2604, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.9.log.2022-08-25.v000154:I0825 23:02:34.681336  161286 stats.go:81] [Metrics][Watch] perc50 571.98964ms, perc90 581.854791ms, perc99 583.52292ms. Total count 2604
```

2020-08-10:
```
--- ec2-52-11-1-193.us-west-2.compute.amazonaws.com
ubuntu@ip-172-31-8-82:~/go/src/global-resource-service$ /usr/local/go/bin/go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-52-11-1-193.us-west-2.compute.amazonaws.com --resource_urls=ec2-54-187-22-27.us-west-2.compute.amazonaws.com:9119,ec2-35-91-52-72.us-west-2.compute.amazonaws.com:9119 --enable_metrics=false -v=3

--- ec2-54-187-22-27.us-west-2.compute.amazonaws.com
ubuntu@ip-172-31-8-205:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=3 -v=3

--- ec2-35-91-52-72.us-west-2.compute.amazonaws.com
ubuntu@ip-172-31-7-9:~/go/src/global-resource-service$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Shanghai --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Outage --wait_time_for_make_rp_down=8 -v=3

--- ec2-54-148-249-172.us-west-2.compute.amazonaws.com
ubuntu@ip-172-31-1-189:~/go/src/global-resource-service$ for i in {1..20}; do sleep 1;   go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-52-11-1-193.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 -v=3 > ~/TMP/scheduler.8.$i.log.2022-08-10.v000070 2>&1 & done

ubuntu@ip-172-31-1-189:~/go/src/global-resource-service$ grep Metrics ~/TMP/scheduler.8.*.log.2022-08-10.v000070
/home/ubuntu/TMP/scheduler.8.1.log.2022-08-10.v000070:I0811 00:00:28.886635    8991 stats.go:44] [Metrics][Register]RegisterClientDuration: 7.276383ms
/home/ubuntu/TMP/scheduler.8.1.log.2022-08-10.v000070:I0811 00:00:28.886651    8991 stats.go:57] [Metrics][List]ListDuration: 644.389349ms. Number of nodes listed: 25104
/home/ubuntu/TMP/scheduler.8.1.log.2022-08-10.v000070:I0811 00:00:28.886661    8991 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000751129s. Number of nodes Added :0, Updated: 1632, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.1.log.2022-08-10.v000070:I0811 00:00:28.886806    8991 stats.go:81] [Metrics][Watch] perc50 690.237556ms, perc90 749.012971ms, perc99 753.209369ms. Total count 1632
/home/ubuntu/TMP/scheduler.8.10.log.2022-08-10.v000070:I0811 00:00:37.896791    9945 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.359441ms
/home/ubuntu/TMP/scheduler.8.10.log.2022-08-10.v000070:I0811 00:00:37.896806    9945 stats.go:57] [Metrics][List]ListDuration: 643.021518ms. Number of nodes listed: 25033
/home/ubuntu/TMP/scheduler.8.10.log.2022-08-10.v000070:I0811 00:00:37.896815    9945 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000630167s. Number of nodes Added :0, Updated: 2273, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.10.log.2022-08-10.v000070:I0811 00:00:37.897031    9945 stats.go:81] [Metrics][Watch] perc50 707.10061ms, perc90 728.504383ms, perc99 739.082034ms. Total count 2273
/home/ubuntu/TMP/scheduler.8.11.log.2022-08-10.v000070:I0811 00:00:38.907610   10051 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.309513ms
/home/ubuntu/TMP/scheduler.8.11.log.2022-08-10.v000070:I0811 00:00:38.907626   10051 stats.go:57] [Metrics][List]ListDuration: 649.772976ms. Number of nodes listed: 25073
/home/ubuntu/TMP/scheduler.8.11.log.2022-08-10.v000070:I0811 00:00:38.907635   10051 stats.go:76] [Metrics][Watch]Watch session last: 30m0.001053851s. Number of nodes Added :0, Updated: 2404, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.11.log.2022-08-10.v000070:I0811 00:00:38.907862   10051 stats.go:81] [Metrics][Watch] perc50 715.664339ms, perc90 739.816271ms, perc99 744.321638ms. Total count 2404
/home/ubuntu/TMP/scheduler.8.12.log.2022-08-10.v000070:I0811 00:00:39.915107   10158 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.061184ms
/home/ubuntu/TMP/scheduler.8.12.log.2022-08-10.v000070:I0811 00:00:39.915155   10158 stats.go:57] [Metrics][List]ListDuration: 656.506083ms. Number of nodes listed: 25026
/home/ubuntu/TMP/scheduler.8.12.log.2022-08-10.v000070:I0811 00:00:39.915166   10158 stats.go:76] [Metrics][Watch]Watch session last: 30m0.00137953s. Number of nodes Added :0, Updated: 3699, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.12.log.2022-08-10.v000070:I0811 00:00:39.915543   10158 stats.go:81] [Metrics][Watch] perc50 712.459491ms, perc90 766.607706ms, perc99 770.047051ms. Total count 3699
/home/ubuntu/TMP/scheduler.8.13.log.2022-08-10.v000070:I0811 00:00:40.909691   10263 stats.go:44] [Metrics][Register]RegisterClientDuration: 4.991462ms
/home/ubuntu/TMP/scheduler.8.13.log.2022-08-10.v000070:I0811 00:00:40.909706   10263 stats.go:57] [Metrics][List]ListDuration: 648.594136ms. Number of nodes listed: 25008
/home/ubuntu/TMP/scheduler.8.13.log.2022-08-10.v000070:I0811 00:00:40.909715   10263 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000345682s. Number of nodes Added :0, Updated: 1857, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.13.log.2022-08-10.v000070:I0811 00:00:40.909900   10263 stats.go:81] [Metrics][Watch] perc50 695.315635ms, perc90 749.32481ms, perc99 750.952528ms. Total count 1857
/home/ubuntu/TMP/scheduler.8.14.log.2022-08-10.v000070:I0811 00:00:41.917377   10372 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.47144ms
/home/ubuntu/TMP/scheduler.8.14.log.2022-08-10.v000070:I0811 00:00:41.917391   10372 stats.go:57] [Metrics][List]ListDuration: 654.200246ms. Number of nodes listed: 25092
/home/ubuntu/TMP/scheduler.8.14.log.2022-08-10.v000070:I0811 00:00:41.917400   10372 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000767489s. Number of nodes Added :0, Updated: 2321, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.14.log.2022-08-10.v000070:I0811 00:00:41.917608   10372 stats.go:81] [Metrics][Watch] perc50 697.995231ms, perc90 751.07054ms, perc99 759.53314ms. Total count 2321
/home/ubuntu/TMP/scheduler.8.15.log.2022-08-10.v000070:I0811 00:00:42.903033   10472 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.364577ms
/home/ubuntu/TMP/scheduler.8.15.log.2022-08-10.v000070:I0811 00:00:42.903047   10472 stats.go:57] [Metrics][List]ListDuration: 641.404268ms. Number of nodes listed: 25092
/home/ubuntu/TMP/scheduler.8.15.log.2022-08-10.v000070:I0811 00:00:42.903057   10472 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000774183s. Number of nodes Added :0, Updated: 2219, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.15.log.2022-08-10.v000070:I0811 00:00:42.903258   10472 stats.go:81] [Metrics][Watch] perc50 691.151655ms, perc90 745.427476ms, perc99 748.893178ms. Total count 2219
/home/ubuntu/TMP/scheduler.8.16.log.2022-08-10.v000070:I0811 00:00:43.915949   10575 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.187401ms
/home/ubuntu/TMP/scheduler.8.16.log.2022-08-10.v000070:I0811 00:00:43.915964   10575 stats.go:57] [Metrics][List]ListDuration: 652.565233ms. Number of nodes listed: 25096
/home/ubuntu/TMP/scheduler.8.16.log.2022-08-10.v000070:I0811 00:00:43.915974   10575 stats.go:76] [Metrics][Watch]Watch session last: 30m0.001034105s. Number of nodes Added :0, Updated: 2251, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.16.log.2022-08-10.v000070:I0811 00:00:43.916190   10575 stats.go:81] [Metrics][Watch] perc50 699.036161ms, perc90 729.791427ms, perc99 748.418379ms. Total count 2251
/home/ubuntu/TMP/scheduler.8.17.log.2022-08-10.v000070:I0811 00:00:44.915682   10682 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.260982ms
/home/ubuntu/TMP/scheduler.8.17.log.2022-08-10.v000070:I0811 00:00:44.915701   10682 stats.go:57] [Metrics][List]ListDuration: 651.104141ms. Number of nodes listed: 25125
/home/ubuntu/TMP/scheduler.8.17.log.2022-08-10.v000070:I0811 00:00:44.915712   10682 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000990797s. Number of nodes Added :0, Updated: 1940, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.17.log.2022-08-10.v000070:I0811 00:00:44.915889   10682 stats.go:81] [Metrics][Watch] perc50 722.609004ms, perc90 777.737516ms, perc99 779.156441ms. Total count 1940
/home/ubuntu/TMP/scheduler.8.18.log.2022-08-10.v000070:I0811 00:00:45.949978   10790 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.153662ms
/home/ubuntu/TMP/scheduler.8.18.log.2022-08-10.v000070:I0811 00:00:45.950001   10790 stats.go:57] [Metrics][List]ListDuration: 685.575131ms. Number of nodes listed: 25048
/home/ubuntu/TMP/scheduler.8.18.log.2022-08-10.v000070:I0811 00:00:45.950010   10790 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000799624s. Number of nodes Added :0, Updated: 2840, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.18.log.2022-08-10.v000070:I0811 00:00:45.950305   10790 stats.go:81] [Metrics][Watch] perc50 712.98074ms, perc90 762.174638ms, perc99 766.416389ms. Total count 2840
/home/ubuntu/TMP/scheduler.8.19.log.2022-08-10.v000070:I0811 00:00:46.923547   10894 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.175354ms
/home/ubuntu/TMP/scheduler.8.19.log.2022-08-10.v000070:I0811 00:00:46.923565   10894 stats.go:57] [Metrics][List]ListDuration: 649.54743ms. Number of nodes listed: 25058
/home/ubuntu/TMP/scheduler.8.19.log.2022-08-10.v000070:I0811 00:00:46.923575   10894 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000683539s. Number of nodes Added :0, Updated: 2864, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.19.log.2022-08-10.v000070:I0811 00:00:46.923843   10894 stats.go:81] [Metrics][Watch] perc50 702.227843ms, perc90 776.582695ms, perc99 777.262598ms. Total count 2864
/home/ubuntu/TMP/scheduler.8.2.log.2022-08-10.v000070:I0811 00:00:29.904647    9094 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.436461ms
/home/ubuntu/TMP/scheduler.8.2.log.2022-08-10.v000070:I0811 00:00:29.904670    9094 stats.go:57] [Metrics][List]ListDuration: 658.826742ms. Number of nodes listed: 25069
/home/ubuntu/TMP/scheduler.8.2.log.2022-08-10.v000070:I0811 00:00:29.904680    9094 stats.go:76] [Metrics][Watch]Watch session last: 30m0.001468985s. Number of nodes Added :0, Updated: 3471, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.2.log.2022-08-10.v000070:I0811 00:00:29.905038    9094 stats.go:81] [Metrics][Watch] perc50 722.506651ms, perc90 767.343494ms, perc99 769.901433ms. Total count 3471
/home/ubuntu/TMP/scheduler.8.3.log.2022-08-10.v000070:I0811 00:00:30.892844    9201 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.389501ms
/home/ubuntu/TMP/scheduler.8.3.log.2022-08-10.v000070:I0811 00:00:30.892860    9201 stats.go:57] [Metrics][List]ListDuration: 648.741826ms. Number of nodes listed: 25116
/home/ubuntu/TMP/scheduler.8.3.log.2022-08-10.v000070:I0811 00:00:30.892869    9201 stats.go:76] [Metrics][Watch]Watch session last: 30m0.001316538s. Number of nodes Added :0, Updated: 2627, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.3.log.2022-08-10.v000070:I0811 00:00:30.893135    9201 stats.go:81] [Metrics][Watch] perc50 714.372115ms, perc90 752.558049ms, perc99 760.04368ms. Total count 2627
/home/ubuntu/TMP/scheduler.8.4.log.2022-08-10.v000070:I0811 00:00:31.905721    9306 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.446178ms
/home/ubuntu/TMP/scheduler.8.4.log.2022-08-10.v000070:I0811 00:00:31.905736    9306 stats.go:57] [Metrics][List]ListDuration: 659.46491ms. Number of nodes listed: 25050
/home/ubuntu/TMP/scheduler.8.4.log.2022-08-10.v000070:I0811 00:00:31.905745    9306 stats.go:76] [Metrics][Watch]Watch session last: 30m0.001003732s. Number of nodes Added :0, Updated: 2401, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.4.log.2022-08-10.v000070:I0811 00:00:31.905964    9306 stats.go:81] [Metrics][Watch] perc50 728.672774ms, perc90 777.715527ms, perc99 778.815759ms. Total count 2401
/home/ubuntu/TMP/scheduler.8.5.log.2022-08-10.v000070:I0811 00:00:32.934035    9414 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.666267ms
/home/ubuntu/TMP/scheduler.8.5.log.2022-08-10.v000070:I0811 00:00:32.934050    9414 stats.go:57] [Metrics][List]ListDuration: 692.990975ms. Number of nodes listed: 25004
/home/ubuntu/TMP/scheduler.8.5.log.2022-08-10.v000070:I0811 00:00:32.934059    9414 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000671721s. Number of nodes Added :0, Updated: 3792, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.5.log.2022-08-10.v000070:I0811 00:00:32.934440    9414 stats.go:81] [Metrics][Watch] perc50 717.007435ms, perc90 764.365575ms, perc99 769.613502ms. Total count 3792
/home/ubuntu/TMP/scheduler.8.6.log.2022-08-10.v000070:I0811 00:00:33.925021    9521 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.381699ms
/home/ubuntu/TMP/scheduler.8.6.log.2022-08-10.v000070:I0811 00:00:33.925037    9521 stats.go:57] [Metrics][List]ListDuration: 669.232857ms. Number of nodes listed: 25064
/home/ubuntu/TMP/scheduler.8.6.log.2022-08-10.v000070:I0811 00:00:33.925047    9521 stats.go:76] [Metrics][Watch]Watch session last: 30m0.00051558s. Number of nodes Added :0, Updated: 2394, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.6.log.2022-08-10.v000070:I0811 00:00:33.925270    9521 stats.go:81] [Metrics][Watch] perc50 698.310271ms, perc90 759.130778ms, perc99 760.259733ms. Total count 2394
/home/ubuntu/TMP/scheduler.8.7.log.2022-08-10.v000070:I0811 00:00:34.909910    9627 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.344315ms
/home/ubuntu/TMP/scheduler.8.7.log.2022-08-10.v000070:I0811 00:00:34.909930    9627 stats.go:57] [Metrics][List]ListDuration: 650.860143ms. Number of nodes listed: 25002
/home/ubuntu/TMP/scheduler.8.7.log.2022-08-10.v000070:I0811 00:00:34.909939    9627 stats.go:76] [Metrics][Watch]Watch session last: 30m0.001476728s. Number of nodes Added :0, Updated: 2904, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.7.log.2022-08-10.v000070:I0811 00:00:34.910220    9627 stats.go:81] [Metrics][Watch] perc50 708.031112ms, perc90 761.761523ms, perc99 765.030456ms. Total count 2904
/home/ubuntu/TMP/scheduler.8.8.log.2022-08-10.v000070:I0811 00:00:35.907176    9736 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.3615ms
/home/ubuntu/TMP/scheduler.8.8.log.2022-08-10.v000070:I0811 00:00:35.907205    9736 stats.go:57] [Metrics][List]ListDuration: 659.096784ms. Number of nodes listed: 25096
/home/ubuntu/TMP/scheduler.8.8.log.2022-08-10.v000070:I0811 00:00:35.907223    9736 stats.go:76] [Metrics][Watch]Watch session last: 30m0.001131739s. Number of nodes Added :0, Updated: 2395, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.8.log.2022-08-10.v000070:I0811 00:00:35.907472    9736 stats.go:81] [Metrics][Watch] perc50 702.590542ms, perc90 768.482478ms, perc99 770.140421ms. Total count 2395
/home/ubuntu/TMP/scheduler.8.9.log.2022-08-10.v000070:I0811 00:00:36.911089    9838 stats.go:44] [Metrics][Register]RegisterClientDuration: 5.141763ms
/home/ubuntu/TMP/scheduler.8.9.log.2022-08-10.v000070:I0811 00:00:36.911105    9838 stats.go:57] [Metrics][List]ListDuration: 657.322761ms. Number of nodes listed: 25041
/home/ubuntu/TMP/scheduler.8.9.log.2022-08-10.v000070:I0811 00:00:36.911116    9838 stats.go:76] [Metrics][Watch]Watch session last: 30m0.000862364s. Number of nodes Added :0, Updated: 1936, Deleted: 0. watch prolonged than 1s: 0
/home/ubuntu/TMP/scheduler.8.9.log.2022-08-10.v000070:I0811 00:00:36.911293    9838 stats.go:81] [Metrics][Watch] perc50 692.937471ms, perc90 754.437694ms, perc99 757.18936ms. Total count 1936

```