### PR TITLE
Eligible sleep between simulator and scheduler, scheduler on same client machine

### DIFF
--- a/hack/test-config.sh
+++ b/hack/test-config.sh
@@ -88,6 +88,7 @@ SERVICE_EXTRA_ARGS=${SERVICE_EXTRA_ARGS:-}
 SIM_EXTRA_ARGS=${SIM_EXTRA_ARGS:-}
 CLIENT_EXTRA_ARGS=${CLIENT_EXTRA_ARGS:-}
 SIM_PORT=${SIM_PORT:-"9119"}
+SCHEDULER_START_DELAY=${SCHEDULER_START_DELAY:-2}   ##using between each scheduler, when starting multi scheduler on one client machine 
 
 SIM_REGIONS=${SIM_REGIONS:-"Beijing,Shanghai"}
 SIM_RP_NUM=${SIM_RP_NUM:-"10"}

--- a/hack/test-rune2e.sh
+++ b/hack/test-rune2e.sh
@@ -104,6 +104,8 @@ function get-num-nodes {
         echo "$((${SIM_NUM}*${SIM_RP_NUM}*${NODES_PER_RP}))"
 }
 
+#TODO: 10M suggested_delay_second is an estimated number and may change base on test result
+#1M/2M/5M suggested_delay_second was tested and verified.
 function get-delay-second {
   local suggested_delay_second=10
   if [[ "$(get-num-nodes)" -ge "1000000" ]]; then

--- a/hack/test-rune2e.sh
+++ b/hack/test-rune2e.sh
@@ -92,11 +92,33 @@ function start-scheduler {
         args+=" ${extra_args}"
         log_file="${name}.log"
         for (( i=0; i<${service_num}; i++ )); do
-                sleep 1
+                sleep ${SCHEDULER_START_DELAY}
                 gocmd=" && /usr/local/go/bin/go run resource-management/test/e2e/singleClientTest.go ${args} > ${SIM_LOG_DIR}/${log_file}.$i 2>&1 &"
                 sshcmd="${cmd}${gocmd}"
                 ssh-config "${sshcmd}" "${name}" "${zone}"
         done
+}
+
+# Returns the total number of resourcemanagement managed.
+function get-num-nodes {
+        echo "$((${SIM_NUM}*${SIM_RP_NUM}*${NODES_PER_RP}))"
+}
+
+function get-delay-second {
+  local suggested_delay_second=10
+  if [[ "$(get-num-nodes)" -ge "1000000" ]]; then
+    suggested_delay_second=20
+  fi
+  if [[ "$(get-num-nodes)" -ge "2000000" ]]; then
+    suggested_delay_second=40
+  fi
+  if [[ "$(get-num-nodes)" -ge "5000000" ]]; then
+    suggested_delay_second=180
+  fi
+  if [[ "$(get-num-nodes)" -ge "10000000" ]]; then
+    suggested_delay_second=600
+  fi
+  echo "${suggested_delay_second}"
 }
 
 ###############
@@ -108,7 +130,6 @@ IFS=','; INSTANCE_SIM_ZONE=($SIM_ZONE); unset IFS;
 IFS=','; INSTANCE_CLIENT_ZONE=($CLIENT_ZONE); unset IFS;
 IFS=','; SIM_REGION_LIST=($SIM_REGIONS); unset IFS;
 IFS=','; SIM_DOWN_TIME_LIST=($SIM_WAIT_DOWN_TIME); unset IFS;
-
 
 ###TODO
 ###using go run to start all component for now
@@ -162,8 +183,8 @@ if [ ${SIM_NUM} -gt 0 ]; then
         fi
 fi
 
-echo "Waiting 10 seconds to get simulator running"
-sleep 10
+echo "Waiting $(get-delay-second) seconds to get simulator running"
+sleep $(get-delay-second)
 
 if [ ${CLIENT_NUM} -gt 0 ]; then
         if [[ "${SERVICE_URL}" != "" ]]; then
@@ -200,5 +221,4 @@ if [ ${CLIENT_NUM} -gt 0 ]; then
                 echo "Failed to start scheduler service, Please ensure SERVICE_URL: ${SERVICE_URL} is correct"
         fi
 fi
-
 echo "Testing is running now, Please remember to run ./hack/test-logcollect.sh to collect logs once testing finished"


### PR DESCRIPTION
1. Add env var: SCHEDULER_START_DELAY and set default value to 2; which is the sleep delay between scheduler on same client machine
2. add eligible sleep between starting simulator and scheduler
3. tested on 5M nodes using the config below:
```
sonyali@sonyaowndev:~/go/src/global-resource-service$ export GRS_INSTANCE_PREFIX=grs-daily-0825-100x50 AUTORUN_E2E=true SIM_NUM=5 CLIENT_NUM=5 SERVER_NUM=1
sonyali@sonyaowndev:~/go/src/global-resource-service$ export SERVER_ZONE=us-central1-a   SIM_ZONE=us-central1-a,us-east1-b,us-west2-a,us-west4-a,us-west3-c CLIENT_ZONE=us-west3-b,us-east4-b,us-central1-b,us-east1-c,us-central1-a
sonyali@sonyaowndev:~/go/src/global-resource-service$ export SERVICE_EXTRA_ARGS="--enable_metrics=false"
sonyali@sonyaowndev:~/go/src/global-resource-service$ export SIM_REGIONS="Beijing,Shanghai,Wulan,Guizhou,Reserved1" SIM_RP_NUM=40 NODES_PER_RP=25000 SCHEDULER_REQUEST_MACHINE=50000 SCHEDULER_REQUEST_LIMIT=51000 SCHEDULER_NUM=100
sonyali@sonyaowndev:~/go/src/global-resource-service$ export SIM_DATA_PATTERN=Daily
sonyali@sonyaowndev:~/go/src/global-resource-service$ ./hack/test-setup.sh
```

Test Result Summary as below:
[result-082622-043813.csv](https://github.com/CentaurusInfra/global-resource-service/files/9429883/result-082622-043813.csv)

