### PR TITLE
change scheduler delay time for 1M/2M

### DIFF
--- a/hack/test-rune2e.sh
+++ b/hack/test-rune2e.sh
@@ -109,10 +109,10 @@ function get-num-nodes {
 function get-delay-second {
   local suggested_delay_second=10
   if [[ "$(get-num-nodes)" -ge "1000000" ]]; then
-    suggested_delay_second=20
+    suggested_delay_second=30
   fi
   if [[ "$(get-num-nodes)" -ge "2000000" ]]; then
-    suggested_delay_second=40
+    suggested_delay_second=90
   fi
   if [[ "$(get-num-nodes)" -ge "5000000" ]]; then
     suggested_delay_second=180


### PR DESCRIPTION
Change delay time between silulator and scheduler for 1M/2M:
1M: change to 30s from previous 20s.
2M: change to 90s from previous 40s.

tested on 2M and latency has 5% improve after changing to 90s. Please check more detail from test result at sonyadev4:/home/sonyali/grs/logs/2000000/Outage/083022-174806