### PR TITLE
Add function GetBatchNodeIDsInquiry for redis store

### DIFF
--- a/resource-management/cmds/service-api/app/server.go
+++ b/resource-management/cmds/service-api/app/server.go
@@ -45,7 +45,7 @@ type Config struct {
 func Run(c *Config) error {
 	klog.V(3).Infof("Starting the API server...")
 
-	store := redis.NewRedisClient()
+	store := redis.NewRedisClient(c.MasterIp, true)
 	dist := distributor.GetResourceDistributor()
 	dist.SetPersistHelper(store)
 	installer := endpoints.NewInstaller(dist)


### PR DESCRIPTION
This PR is to 
1) add function BatchLogicalNodsInquiry for Redis store, which is used by batch logicalNode status inquiry.
2) add UT test for function BatchLogicalNodesInquiry

Please Note: this PR only support Redis-server local only, another new PR will be for Redis-server remote support.

The codes have been tested successfully in local MAC development and my AWS integration test environment (500K nodes/2 regions/20 schedulers).

1. UT in local MAC development:
```
carl@Carls-MacBook-Pro redis % go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestSetGettString
--- PASS: TestSetGettString (0.00s)
=== RUN   TestPersistNodes
--- PASS: TestPersistNodes (0.00s)
=== RUN   TestPersistNodeStoreStatus
--- PASS: TestPersistNodeStoreStatus (0.00s)
=== RUN   TestPersistVirtualNodesAssignments
--- PASS: TestPersistVirtualNodesAssignments (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:215: 
        First test is starting
    redis_test.go:259: Scan (2) logical nodes and actually get (2) logical nodes
    redis_test.go:262: Index #(0): 
    redis_test.go:263: =================
    redis_test.go:264: Id:        (0003)
    redis_test.go:265: Region:    (1002)
    redis_test.go:266: RP:        (1002)
    redis_test.go:262: Index #(1): 
    redis_test.go:263: =================
    redis_test.go:264: Id:        (0002)
    redis_test.go:265: Region:    (1001)
    redis_test.go:266: RP:        (1001)
    redis_test.go:268: 
        First test is OK
        
    redis_test.go:271: 
        Second test is starting
    redis_test.go:316: Scan (10) logical nodes and actually get (12) logical nodes
    redis_test.go:317: 
        Second test is OK
        
    redis_test.go:320: 
        Third test is starting
    redis_test.go:332: Scan (1000) logical nodes and actually get (1000) logical nodes
    redis_test.go:333: 
        Third test is OK
        
    redis_test.go:336: 
        Fourth test is starting
    redis_test.go:348: Scan (2000) logical nodes and actually get (2003) logical nodes
    redis_test.go:349: 
        Fouth test is OK
        
    redis_test.go:352: 
        The fifth test is starting
    redis_test.go:360: Scan (20000) logical nodes and actually get (10002) logical nodes
    redis_test.go:361: 
        Fifth test is OK
        
--- PASS: TestBatchLogicalNodeInquiry (1.45s)
PASS
ok  	global-resource-service/resource-management/pkg/store/redis	1.639s
```

```
carl@Carls-MacBook-Pro redis % go test   
PASS
ok  	global-resource-service/resource-management/pkg/store/redis	1.781s
```

Integration test for inquiry on AWS EC2 instance running service_api:
```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:316: Scan (10) logical nodes and actually get (10) logical nodes
    redis_test.go:317:
        Second test is OK

    redis_test.go:320:
        Third test is starting
    redis_test.go:332: Scan (1000) logical nodes and actually get (1001) logical nodes
    redis_test.go:333:
        Third test is OK

    redis_test.go:336:
        Fourth test is starting
    redis_test.go:348: Scan (2000) logical nodes and actually get (2000) logical nodes
    redis_test.go:349:
        Fouth test is OK

    redis_test.go:352:
        The fifth test is starting
    redis_test.go:360: Scan (20000) logical nodes and actually get (20000) logical nodes
    redis_test.go:361:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (3.09s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     3.095s
```

```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:316: Scan (10) logical nodes and actually get (11) logical nodes
    redis_test.go:317:
        Second test is OK

    redis_test.go:320:
        Third test is starting
    redis_test.go:332: Scan (1000) logical nodes and actually get (1000) logical nodes
    redis_test.go:333:
        Third test is OK

    redis_test.go:336:
        Fourth test is starting
    redis_test.go:348: Scan (2000) logical nodes and actually get (2000) logical nodes
    redis_test.go:349:
        Fouth test is OK

    redis_test.go:352:
        The fifth test is starting
    redis_test.go:360: Scan (3000) logical nodes and actually get (3000) logical nodes
    redis_test.go:361:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (0.87s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     0.877s
```

Integration test for inquiry on cross-region machine:
```
ubuntu@ip-172-31-17-152:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:316: Scan (10) logical nodes and actually get (11) logical nodes
    redis_test.go:317:
        Second test is OK

    redis_test.go:320:
        Third test is starting
    redis_test.go:332: Scan (1000) logical nodes and actually get (1000) logical nodes
    redis_test.go:333:
        Third test is OK

    redis_test.go:336:
        Fourth test is starting
    redis_test.go:348: Scan (2000) logical nodes and actually get (2000) logical nodes
    redis_test.go:349:
        Fouth test is OK

    redis_test.go:352:
        The fifth test is starting
    redis_test.go:360: Scan (3000) logical nodes and actually get (3000) logical nodes
    redis_test.go:361:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (124.49s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     124.491s
```

```
ubuntu@ip-172-31-17-152:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:316: Scan (10) logical nodes and actually get (11) logical nodes
    redis_test.go:317:
        Second test is OK

    redis_test.go:320:
        Third test is starting
    redis_test.go:332: Scan (1000) logical nodes and actually get (1000) logical nodes
    redis_test.go:333:
        Third test is OK

    redis_test.go:336:
        Fourth test is starting
    redis_test.go:348: Scan (2000) logical nodes and actually get (2000) logical nodes
    redis_test.go:349:
        Fouth test is OK

    redis_test.go:352:
        The fifth test is starting
    redis_test.go:360: Scan (3000) logical nodes and actually get (3000) logical nodes
    redis_test.go:361:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (125.11s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     125.115s
```