### PR TITLE
Enable Redis Server 7.0 remote support for batch logical node inquiry

### DIFF
--- a/hack/redis_install.sh
+++ b/hack/redis_install.sh
@@ -88,10 +88,35 @@ if [ `uname -s` == "Linux" ]; then
     sudo sed -i -e "s/^appendonly no$/appendonly yes/g" $REDIS_CONF_Ubuntu
     sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(appendonly |appendfsync )"
 
+    # === Enable Redis server remote support
+    sudo sed -i -e "s/^bind 127.0.0.1 -::1$/bind 0.0.0.0/g" $REDIS_CONF_Ubuntu
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(bind 0.0.0.0)"
+
+    sudo sed -i -e "s/^protected-mode yes$/protected-mode no/g" $REDIS_CONF_Ubuntu
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(protected-mode no)"
+    # === Enable Redis server remote support
+
+    #
+    # Note: do not forget to open redis port 6379 in AWS Ubuntu OS level or GCE level
+    #
+    # For example: Open port 6379 with ufw on AWS 
+    # $ sudo ufw status
+    # $ sudo ufw allow 6379/tcp
+    # $ sudo ufw status
+    #
+    # if ufw status is inactive, please enable ufw
+    # $ sudo ufw enable
+    # $ sudo ufw status
+    #
+
+    # Restart redis-server as a service
     sudo ls -al /lib/systemd/system/ |grep redis
 
     sudo systemctl restart redis-server.service
     sudo systemctl status redis-server.service
+
+    # Check whether network port 6379 is listened
+    sudo netstat -nlpt | grep 6379
   else
     echo ""
     echo "This Linux OS ($LinuxOS) is currently not supported and exit"


### PR DESCRIPTION
This PR is to ensure Redis server 7.0 to have remote support function is automatically enabled after automatic installation on Ubuntu OS 18.04 and 20.04. The codes of script have been tested successfully on AWS Ubuntu18.04 and Ubuntu20.04.

Also, plus PR155, simply change "localhost" to "remote machine's public IP" or "remote machine's public hostname" in redis_test.go, UT from another remote machine on AWS region us-west-1 over service-api machine on AWS region us-west-2 (cross-region) has been successful.

UT on remote machine on AWS region us-west-1 over service-api machine on AWS region us-west-2:

service-api machine on AWS region us-west-2:
```
52.11.1.193
OR
ec2-52-11-1-193.us-west-2.compute.amazonaws.com
```

another remote machine on AWS region us-west-1:
```
ubuntu@ip-172-31-17-152:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.07s)
=== RUN   TestSetGettString
--- PASS: TestSetGettString (0.04s)
=== RUN   TestPersistNodes
--- PASS: TestPersistNodes (0.06s)
=== RUN   TestPersistNodeStoreStatus
--- PASS: TestPersistNodeStoreStatus (0.04s)
=== RUN   TestPersistVirtualNodesAssignments
--- PASS: TestPersistVirtualNodesAssignments (0.04s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:215:
        First test is starting
    redis_test.go:261: Index #(0):
    redis_test.go:262: =================
    redis_test.go:263: Id:        (0003)
    redis_test.go:264: Region:    (1002)
    redis_test.go:265: RP:        (1002)
    redis_test.go:261: Index #(1):
    redis_test.go:262: =================
    redis_test.go:263: Id:        (0002)
    redis_test.go:264: Region:    (1001)
    redis_test.go:265: RP:        (1001)
    redis_test.go:267:
        First test is OK

    redis_test.go:270:
        Second test is starting
    redis_test.go:311:
        Second test is OK

    redis_test.go:314:
        Third test is starting
    redis_test.go:322:
        Third test is OK

    redis_test.go:325:
        Fourth test is starting
    redis_test.go:333:
        Fouth test is OK

    redis_test.go:336:
        The fifth test is starting
    redis_test.go:344:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (83.88s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     84.198s

```

The third, plus PR155, simply comment out other unnecessary codes but keep the codes for "batch logical node inquiry" ONLY, the integration test for "batch logical node inquiry" ONLY from another remote machine on AWS region us-west-1 over service-api machine on AWS region us-west-2  has been successful when service-api/simulators (500K nodes/2 regions/20 schedulers) are running on AWS region us-west-2.

UT on remote machine on AWS region us-west-1 over service-api machine on AWS region us-west-2:

service-api machine on AWS region us-west-2:
```
52.11.1.193
OR
ec2-52-11-1-193.us-west-2.compute.amazonaws.com
```

another remote machine on AWS region us-west-1:
```
ubuntu@ip-172-31-17-152:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:313:
        Second test is OK

    redis_test.go:316:
        Third test is starting
    redis_test.go:324:
        Third test is OK

    redis_test.go:327:
        Fourth test is starting
    redis_test.go:335:
        Fouth test is OK

    redis_test.go:338:
        The fifth test is starting
    redis_test.go:346:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (59.58s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     59.587s
```
