### PR TITLE
remove instance group from test setup

### DIFF
--- a/hack/test-logcollect.sh
+++ b/hack/test-logcollect.sh
@@ -75,44 +75,29 @@ export COLLECTDATE="$(date +"%m%d%y-%H%M%S")"
 export DESTINATION="${DES_LOG_DIR}/${COLLECTDATE}"
 if [ ${SERVER_NUM} -gt 0 ]; then
         echo "Collecting logs from ${#INSTANCE_SERVER_ZONE[@]} server machines: "
-        if [ ${#INSTANCE_SERVER_ZONE[@]} == 1 ]; then
-                collect-log-mig "${SERVER_INSTANCE_PREFIX}-${INSTANCE_SERVER_ZONE[0]}-mig" "${INSTANCE_SERVER_ZONE[0]}" "${SERVER_LOG_DIR}" "${DESTINATION}"
-        else
-                index=0
-                for zone in "${INSTANCE_SERVER_ZONE[@]}"; do
-                        collect-log-instance "${SERVER_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" "${SERVER_LOG_DIR}" "${DESTINATION}"
-                        index=$(($index + 1)) 
-                done
-
-        fi
+        index=0
+        for zone in "${INSTANCE_SERVER_ZONE[@]}"; do
+                collect-log-instance "${SERVER_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" "${SERVER_LOG_DIR}" "${DESTINATION}"
+                index=$(($index + 1)) 
+        done
 fi
 
 if [ ${CLIENT_NUM} -gt 0 ]; then
         echo "Collecting logs from ${#INSTANCE_CLIENT_ZONE[@]} client machines: "
-        if [ ${#INSTANCE_CLIENT_ZONE[@]} == 1 ]; then
-                collect-log-mig "${CLIENT_INSTANCE_PREFIX}-${INSTANCE_CLIENT_ZONE[0]}-mig" "${INSTANCE_CLIENT_ZONE[0]}" "${CLIENT_LOG_DIR}" "${DESTINATION}"
-        else
-                index=0
-                for zone in "${INSTANCE_CLIENT_ZONE[@]}"; do
-                        collect-log-instance "${CLIENT_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" "${CLIENT_LOG_DIR}" "${DESTINATION}"
-                        index=$(($index + 1)) 
-                done
-
-        fi
+        index=0
+        for zone in "${INSTANCE_CLIENT_ZONE[@]}"; do
+                collect-log-instance "${CLIENT_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" "${CLIENT_LOG_DIR}" "${DESTINATION}"
+                index=$(($index + 1)) 
+        done
 fi
 
 if [ ${SIM_NUM} -gt 0 ]; then
         echo "Collecting logs from ${#INSTANCE_SIM_ZONE[@]} simulator machines: "
-        if [ ${#INSTANCE_SIM_ZONE[@]} == 1 ]; then
-                collect-log-mig "${SIM_INSTANCE_PREFIX}-${INSTANCE_SIM_ZONE[0]}-mig" "${INSTANCE_SIM_ZONE[0]}" "${SIM_LOG_DIR}" "${DESTINATION}"
-        else
-                index=0
-                for zone in "${INSTANCE_SIM_ZONE[@]}"; do
-                        collect-log-instance "${SIM_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" "${SIM_LOG_DIR}" "${DESTINATION}"
-                        index=$(($index + 1)) 
-                done
-
-        fi
+        index=0
+        for zone in "${INSTANCE_SIM_ZONE[@]}"; do
+                collect-log-instance "${SIM_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" "${SIM_LOG_DIR}" "${DESTINATION}"
+                index=$(($index + 1)) 
+        done
 fi
 
 "${GRS_ROOT}/hack/test-loganalysis.sh"

--- a/hack/test-teardown.sh
+++ b/hack/test-teardown.sh
@@ -88,20 +88,14 @@ function delete-machine-image {
 if [[ "${SIM_AUTO_DELETE}" == "true" && ${SIM_NUM} -gt 0 ]]; then
         echo "Deleting simulator resources"
         IFS=','; INSTANCE_SIM_ZONE=($SIM_ZONE); unset IFS;
-        if [ ${#INSTANCE_SIM_ZONE[@]} == 1 ]; then
-                delete-instance-groups "${SIM_INSTANCE_PREFIX}-${INSTANCE_SIM_ZONE[0]}-mig" "${INSTANCE_SIM_ZONE[0]}"
-                delete-instance-template "${SIM_INSTANCE_PREFIX}-template"
-        else
-                index=0
-                for zone in "${INSTANCE_SIM_ZONE[@]}"; do
-                        delete-vm-instance "${SIM_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" &
-                        index=$(($index + 1)) 
-                done
-        fi
+        index=0
+        for zone in "${INSTANCE_SIM_ZONE[@]}"; do
+                delete-vm-instance "${SIM_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" &
+                index=$(($index + 1)) 
+        done
         if [ "${SIMIMAGE_AUTO_DELETE}" == "true" ]; then
                 #waiting 60 seconds to get all instances deleted before delete images
                 sleep 60
-                delete-image "${SIM_IMAGE_NAME}"
                 delete-machine-image  "${SIM_IMAGE_NAME}"
         fi
 fi
@@ -109,20 +103,14 @@ fi
 if [[ "${CLIENT_AUTO_DELETE}" == "true"  && ${CLIENT_NUM} -gt 0 ]]; then
         echo "Deleting client scheduler resources"
         IFS=','; INSTANCE_CLIENT_ZONE=($CLIENT_ZONE); unset IFS;
-        if [ ${#INSTANCE_CLIENT_ZONE[@]} == 1 ]; then
-                delete-instance-groups "${CLIENT_INSTANCE_PREFIX}-${INSTANCE_CLIENT_ZONE[0]}-mig" "${INSTANCE_CLIENT_ZONE[0]}"
-                delete-instance-template "${CLIENT_INSTANCE_PREFIX}-template"
-        else
-                index=0
-                for zone in "${INSTANCE_CLIENT_ZONE[@]}"; do
-                        delete-vm-instance "${CLIENT_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" &
-                        index=$(($index + 1)) 
-                done
-        fi
+        index=0
+        for zone in "${INSTANCE_CLIENT_ZONE[@]}"; do
+                delete-vm-instance "${CLIENT_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" &
+                index=$(($index + 1)) 
+        done
         if [ "${CLIENTIMAGE_AUTO_DELETE}" == "true" ]; then
                 #waiting 60 seconds to get all instances deleted before delete images
                 sleep 60
-                delete-image "${CLIENT_IMAGE_NAME}"
                 delete-machine-image  "${CLIENT_IMAGE_NAME}"
         fi
 fi
@@ -130,20 +118,14 @@ fi
 if [[ "${SERVER_AUTO_DELETE}" == "true"  && ${SERVER_NUM} -gt 0 ]]; then
         echo "Deleting server resources"
         IFS=','; INSTANCE_SERVER_ZONE=($SERVER_ZONE); unset IFS;
-        if [ ${#INSTANCE_SERVER_ZONE[@]} == 1 ]; then
-                delete-instance-groups "${SERVER_INSTANCE_PREFIX}-${INSTANCE_SERVER_ZONE[0]}-mig" "${INSTANCE_SERVER_ZONE[0]}"
-                delete-instance-template "${SERVER_INSTANCE_PREFIX}-template"
-        else
-                index=0
-                for zone in "${INSTANCE_SERVER_ZONE[@]}"; do
-                        delete-vm-instance "${SERVER_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" &
-                        index=$(($index + 1)) 
-                done
-        fi
+        index=0
+        for zone in "${INSTANCE_SERVER_ZONE[@]}"; do
+                delete-vm-instance "${SERVER_INSTANCE_PREFIX}-${zone}-${index}" "${zone}" &
+                index=$(($index + 1)) 
+        done
         if [ "${SERVERIMAGE_AUTO_DELETE}" == "true" ]; then
                 #waiting 60 seconds to get all instances deleted before delete images
                 sleep 60
-                delete-image "${SERVER_IMAGE_NAME}"
                 delete-machine-image  "${SERVER_IMAGE_NAME}"
         fi
 fi


### PR DESCRIPTION
previous test-setup.sh has constraint: if resource num equals 1, using instance group and image to generate VMS, in this case, VMS can only be created with same template machine zone.

this PR removed instance group and using machine image to create all vms, now vm can be created in any assigned zones.