### PR TITLE
<Simulator_List_Watch> Add sleep time  before daily pattern starts to create modified events

### DIFF
--- a/resource-management/test/resourceRegionMgrSimulator/app/simulator.go
+++ b/resource-management/test/resourceRegionMgrSimulator/app/simulator.go
@@ -30,12 +30,12 @@ import (
 )
 
 type RegionConfig struct {
-	RegionName            string
-	RpNum                 int
-	NodesPerRP            int
-	MasterPort            string
-	DataPattern           string
-	WaitTimeForMakeRpDown int
+	RegionName                   string
+	RpNum                        int
+	NodesPerRP                   int
+	MasterPort                   string
+	DataPattern                  string
+	WaitTimeForDataChangePattern int
 }
 
 func Run(c *RegionConfig) error {

--- a/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
+++ b/resource-management/test/resourceRegionMgrSimulator/data/regionNodeEvents.go
@@ -64,13 +64,13 @@ func Init(regionName string, rpNum, nodesPerRP int) {
 // Generate region node update event changes to
 // add them into RegionNodeEventsList
 //
-func MakeDataUpdate(data_pattern string, wait_time_for_make_rp_down int) {
-	go func(data_pattern string, wait_time_for_make_rp_down int) {
+func MakeDataUpdate(data_pattern string, wait_time_for_data_change_pattern int) {
+	go func(data_pattern string, wait_time_for_data_change_pattern int) {
 		switch data_pattern {
 		case "Outage":
 			for {
 				// Generate one RP down event during specfied interval
-				time.Sleep(time.Duration(wait_time_for_make_rp_down) * time.Minute)
+				time.Sleep(time.Duration(wait_time_for_data_change_pattern) * time.Minute)
 				makeOneRPDown()
 				klog.V(3).Info("Generating one RP down event is completed")
 
@@ -78,6 +78,9 @@ func MakeDataUpdate(data_pattern string, wait_time_for_make_rp_down int) {
 				klog.V(6).Info("Simulate to delay 2 hours")
 			}
 		case "Daily":
+			//Sleep time ensures schedulers complete 25K-node list before modified events are created
+			time.Sleep(time.Duration(wait_time_for_data_change_pattern) * time.Minute)
+
 			for {
 				// At each minute mark, generate 10 modified node events
 				time.Sleep(1 * time.Minute)
@@ -89,7 +92,7 @@ func MakeDataUpdate(data_pattern string, wait_time_for_make_rp_down int) {
 			klog.V(3).Infof("Current Simulator Data Pattern (%v) is supported", data_pattern)
 			return
 		}
-	}(data_pattern, wait_time_for_make_rp_down)
+	}(data_pattern, wait_time_for_data_change_pattern)
 }
 
 ///////////////////////////////////////////////

--- a/resource-management/test/resourceRegionMgrSimulator/main.go
+++ b/resource-management/test/resourceRegionMgrSimulator/main.go
@@ -39,7 +39,7 @@ func main() {
 	flag.IntVar(&c.NodesPerRP, "nodes_per_rp", 25000, "The number of RPs per region, if not set, default to 25000")
 	flag.StringVar(&c.MasterPort, "master_port", "9119", "Service port, if not set, default to 9119")
 	flag.StringVar(&c.DataPattern, "data_pattern", "Outage", "Simulator data pattern, if not set, default to Outage Mode")
-	flag.IntVar(&c.WaitTimeForMakeRpDown, "wait_time_for_make_rp_down", 5, "Wait time for make rp down, if not set, default to 5")
+	flag.IntVar(&c.WaitTimeForDataChangePattern, "wait_time_for_data_change_pattern", 5, "Wait time for Outage or Daily pattern, if not set, default to 5")
 
 	if !flag.Parsed() {
 		klog.InitFlags(nil)
@@ -69,7 +69,7 @@ func main() {
 	klog.Infof("Region resource manager simulator config / rp number per region: (%v)", c.RpNum)
 	klog.Infof("Region resource manager simulator config / node number per rp:  (%v)", c.NodesPerRP)
 	klog.Infof("Region resource manager simulator config / simulator data pattern:  (%v)", c.DataPattern)
-	klog.Infof("Region resource manager simulator config / wait time for make rp down:  (%v)", c.WaitTimeForMakeRpDown)
+	klog.Infof("Region resource manager simulator config / wait time for Outage or Daily pattern:  (%v)", c.WaitTimeForDataChangePattern)
 
 	klog.Info("")
 	klog.Infof("Starting resource region manager simulator (%v)", c.RegionName)
@@ -77,7 +77,6 @@ func main() {
 
 	// Initialize Added Event List and Modified Event List
 	// Region node Added Event List - for initpull
-	//data.Init(c.RegionName, c.DataPattern, c.RpNum, c.NodesPerRP)
 	data.Init(c.RegionName, c.RpNum, c.NodesPerRP)
 
 	// Generate update changes of Default Pattern
@@ -85,7 +84,7 @@ func main() {
 	// OR
 	// Generate update changes of Daily Pattern
 	// - simulate 10 changes each minute
-	data.MakeDataUpdate(c.DataPattern, c.WaitTimeForMakeRpDown)
+	data.MakeDataUpdate(c.DataPattern, c.WaitTimeForDataChangePattern)
 
 	// Run simulater RSET API server
 	if err := app.Run(c); err != nil {
@@ -98,7 +97,7 @@ func main() {
 // function to print the usage info for the resource management api server
 func printUsage() {
 	fmt.Println("\nUsage: Region Resource Manager Simulator")
-	fmt.Println("\n       Per region config options: --region_name=<region name>  --rp_num=<number of rp>  --nodes_per_rp=<number of nodes> --master_port=<port> --data_pattern=<outage or daily> --wait_time_for_make_rp_down=<number of minutes>")
+	fmt.Println("\n       Per region config options: --region_name=<region name>  --rp_num=<number of rp>  --nodes_per_rp=<number of nodes> --master_port=<port> --data_pattern=<outage or daily> --wait_time_for_data_change_pattern=<number of minutes>")
 	fmt.Println()
 
 	os.Exit(0)


### PR DESCRIPTION
This PR is to allow Daily pattern to add sleeping time before modified events are created to ensure schedulers complete "ListNode" operation.

The codes have been tested in AWS integration test environment (2 regions/500K nodes/20 scheduler clients) below successfully

--- service
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-52-11-1-193.us-west-2.compute.amazonaws.com --resource_urls=ec2-54-187-22-27.us-west-2.compute.amazonaws.com:9119,ec2-35-91-52-72.us-west-2.compute.amazonaws.com:9119 --enable_metrics=false -v=3  > ~/TMP/service.log.2022-09-13.v000168 2>&1 &
```

--- simulators
```
ubuntu@ip-172-31-7-9:~/go/src/GRS$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Shanghai --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Daily --wait_time_for_data_pattern=3 -v=3 > ~/TMP/simulator2.log.2022-09-13.v000168 2>&1 &

ubuntu@ip-172-31-8-205:~/go/src/GRS$ go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Daily --wait_time_for_data_pattern=5 -v=3  > ~/TMP/simulator1.log.2022-09-13.v000168 2>&1 &
```

--- scheduler clients
```
ubuntu@ip-172-31-4-135:~/go/src/GRS$ for i in {1..10}; do sleep 1;   go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-52-11-1-193.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 --request_timeout=30m -v=3 > ~/TMP/scheduler.6.$i.log.2022-09-13.v000168 2>&1 & done

ubuntu@ip-172-31-1-189:~/go/src/GRS$ for i in {1..10}; do sleep 1;   go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-52-11-1-193.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 --request_timeout=30m -v=3 > ~/TMP/scheduler.8.$i.log.2022-09-13.v000168 2>&1 & done
```
