### PR TITLE
Change Redis default port 6379 to new port flexiably

### DIFF
--- a/hack/redis_install.sh
+++ b/hack/redis_install.sh
@@ -37,6 +37,11 @@
 #
 export PATH=$PATH
 
+REDIS_DEFAULT_PORT=${REDIS_DEFAULT_PORT:-6379}
+REDIS_NEW_PORT=${REDIS_NEW_PORT:-7379}
+REDIS_CONF_UBUNTU=${REDIS_CONF_UBUNTU:-"/etc/redis/redis.conf"}
+
+
 if [ `uname -s` == "Linux" ]; then
   LINUX_OS=`uname -v |awk -F'-' '{print $2}' |awk '{print $1}'`
 
@@ -79,29 +84,31 @@ if [ `uname -s` == "Linux" ]; then
     echo ""
     echo "2. Enable and Run Redis ......"
     echo "==============================="
-    REDIS_CONF_Ubuntu=/etc/redis/redis.conf
-    sudo ls -alg $REDIS_CONF_Ubuntu
+    sudo ls -alg $REDIS_CONF_UBUNTU
 
-    sudo sed -i -e "s/^supervised auto$/supervised systemd/g" $REDIS_CONF_Ubuntu
-    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |grep "supervised "
+    sudo sed -i -e "s/^supervised auto$/supervised systemd/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |grep "supervised "
 
-    sudo sed -i -e "s/^appendonly no$/appendonly yes/g" $REDIS_CONF_Ubuntu
-    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(appendonly |appendfsync )"
+    sudo sed -i -e "s/^appendonly no$/appendonly yes/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |egrep "(appendonly |appendfsync )"
 
     # === Enable Redis server remote support
-    sudo sed -i -e "s/^bind 127.0.0.1 -::1$/bind 0.0.0.0/g" $REDIS_CONF_Ubuntu
-    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(bind 0.0.0.0)"
+    sudo sed -i -e "s/^bind 127.0.0.1 -::1$/bind 0.0.0.0/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |egrep "(bind 0.0.0.0)"
 
-    sudo sed -i -e "s/^protected-mode yes$/protected-mode no/g" $REDIS_CONF_Ubuntu
-    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(protected-mode no)"
+    sudo sed -i -e "s/^protected-mode yes$/protected-mode no/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |egrep "(protected-mode no)"
+
+    sudo sed -i -e "s/^port $REDIS_DEFAULT_PORT$/port $REDIS_NEW_PORT/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |egrep "(port $REDIS_NEW_PORT)"
     # === Enable Redis server remote support
 
     #
-    # Note: do not forget to open redis port 6379 in AWS Ubuntu OS level or GCE level
+    # Note: do not forget to open redis port 7379 in AWS Ubuntu OS level or GCE level
     #
-    # For example: Open port 6379 with ufw on AWS 
+    # For example: Open port 7379 with ufw on AWS 
     # $ sudo ufw status
-    # $ sudo ufw allow 6379/tcp
+    # $ sudo ufw allow 7379/tcp
     # $ sudo ufw status
     #
     # if ufw status is inactive, please enable ufw
@@ -115,8 +122,8 @@ if [ `uname -s` == "Linux" ]; then
     sudo systemctl restart redis-server.service
     sudo systemctl status redis-server.service
 
-    # Check whether network port 6379 is listened
-    sudo netstat -nlpt | grep 6379
+    # Check whether network port 7379 is listened
+    sudo netstat -nlpt | grep $REDIS_NEW_PORT
   else
     echo ""
     echo "This Linux OS ($LinuxOS) is currently not supported and exit"
@@ -185,19 +192,20 @@ echo ""
 echo "3. Simply Test Redis ......"
 echo "==============================="
 which redis-cli
+
 echo "3.1) Test ping ......"
-redis-cli ping 
+redis-cli -p $REDIS_NEW_PORT ping 
 
 echo ""
 echo "3.2) Test write key and value ......"
-redis-cli << EOF
+redis-cli -p $REDIS_NEW_PORT << EOF
 SET server:name "fido"
 GET server:name
 EOF
 
 echo ""
 echo "3.3) Test write queue ......"
-redis-cli << EOF
+redis-cli -p $REDIS_NEW_PORT << EOF
 lpush demos redis-macOS-demo
 rpop demos
 EOF

--- a/resource-management/cmds/service-api/app/server.go
+++ b/resource-management/cmds/service-api/app/server.go
@@ -38,14 +38,16 @@ type Config struct {
 	ResourceUrls              []string
 	MasterIp                  string
 	MasterPort                string
+	RedisPort		  string
 	EventMetricsDumpFrequency time.Duration
 }
 
 // Run and create new service-api.  This should never exit.
 func Run(c *Config) error {
 	klog.V(3).Infof("Starting the API server...")
+	klog.V(3).Infof("Connecting the Redis server via port (%v)...", c.RedisPort)
 
-	store := redis.NewRedisClient(c.MasterIp, true)
+	store := redis.NewRedisClient(c.MasterIp, c.RedisPort, false)
 	dist := distributor.GetResourceDistributor()
 	dist.SetPersistHelper(store)
 	installer := endpoints.NewInstaller(dist)

--- a/resource-management/cmds/service-api/service-api.go
+++ b/resource-management/cmds/service-api/service-api.go
@@ -40,6 +40,7 @@ func main() {
 	flag.StringVar(&c.MasterIp, "master_ip", "localhost", "Service IP address, if not set, default to localhost")
 	flag.StringVar(&c.MasterPort, "master_port", "8080", "Service port, if not set, default to 8080")
 	flag.StringVar(&urls, "resource_urls", "", "Resource urls of the resource manager services in each region")
+	flag.StringVar(&c.RedisPort, "redis_port", "7379", "Redis port, if not set, default to 7379")
 	flag.DurationVar(&c.EventMetricsDumpFrequency, "metrics_dump_frequency", 5*time.Minute, "Frequency to dump the event metrics, default 5m")
 	flag.BoolVar(&metricsEnabled, "enable_metrics", true, "Flag for if node event trace is enabled. default is enabled")
 
@@ -92,7 +93,7 @@ func printUsage() {
 	// klog will use commandline log parameters with nil as named a few below:
 	// --alsologtostderr=true  --logtostderr=false --log_file="/tmp/grs.log"
 	fmt.Println("logging options: --alsologtostderr=true  --logtostderr=false --log_file=/tmp/grs.log")
-	fmt.Println("service config options: --master_ip=<master address>  --master_port=<port> --resource_urls=<url1,url2,...>")
+	fmt.Println("service config options: --master_ip=<master address>  --master_port=<port> --redis_port=<port> --resource_urls=<url1,url2,...>")
 	fmt.Println("Explanation: <master address> could be public ip address or public dns name of the server")
 	fmt.Println("Gate flags: --enable_metrics=true  to enable the detailed event trace checkpoints")
 	os.Exit(0)

--- a/resource-management/pkg/store/redis/redis.go
+++ b/resource-management/pkg/store/redis/redis.go
@@ -36,12 +36,8 @@ type Goredis struct {
 	ctx    context.Context
 }
 
-const (
-	redisPort = "6379"
-)
-
 // Initialize Redis Client
-func NewRedisClient(redisServerIP string, flushAllFlag bool) *Goredis {
+func NewRedisClient(redisServerIP string, redisPort string, flushAllFlag bool) *Goredis {
 	redisAddress := fmt.Sprintf("%s:%s", redisServerIP, redisPort)
 
 	client := redis.NewClient(&redis.Options{

--- a/resource-management/pkg/store/redis/redis_test.go
+++ b/resource-management/pkg/store/redis/redis_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package redis
 
 import (
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -29,15 +30,27 @@ import (
 )
 
 var GR, GRInquiry *Goredis
+var redisPort string
+
+func setRedisPort() string {
+	if os.Getenv("REDIS_NEW_PORT") == "" {
+		redisPort = "7379"
+	} else {
+		redisPort = os.Getenv("REDIS_NEW_PORT")
+	}
+
+	return redisPort
+}
 
 func init() {
-	GR = NewRedisClient("localhost", true)
-	GRInquiry = NewRedisClient("localhost", false)
+	redisPort = setRedisPort()
+	GR = NewRedisClient("localhost", redisPort, true)
+	GRInquiry = NewRedisClient("localhost", redisPort, false)
 }
 
 func TestNewRedisClient(t *testing.T) {
-	GR = NewRedisClient("localhost", true)
-	GRInquiry = NewRedisClient("localhost", false)
+	GR = NewRedisClient("localhost", redisPort, true)
+	GRInquiry = NewRedisClient("localhost", redisPort, false)
 }
 
 // Simply Test Set String and Get String without the need of Marshal and Unmarshal
@@ -209,7 +222,7 @@ func TestPersistVirtualNodesAssignments(t *testing.T) {
 //
 func TestBatchLogicalNodeInquiry(t *testing.T) {
 	// Clean redis store to avoid test mess up due to previous tests
-	GR = NewRedisClient("localhost", true)
+	GR = NewRedisClient("localhost", redisPort, true)
 
 	// Start first test
 	t.Log("\nFirst test is starting")


### PR DESCRIPTION
This PR is to make the following changes
1) Flexibly change redis default port from 6379 to new port (default:7379)
2) Automatically redis server installation
3) singleNodeQuery due to the changes of function redis.NewRedisClient

Test1 : new port 8389
1. Installation test:
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ export REDIS_NEW_PORT=8389
ubuntu@ip-172-31-8-82:~/go/src/GRS$ /bin/bash hack/redis_install.sh
```

2. Local and remote connection test:
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ redis-cli -h ec2-52-11-1-193.us-west-2.compute.amazonaws.com -p 8389 info keyspace
db0:keys=1,expires=0,avg_ttl=0

ubuntu@ip-172-31-8-82:~/go/src/GRS$ redis-cli -h ip-172-31-8-82 -p 8389 info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0

ubuntu@ip-172-31-8-82:~/go/src/GRS$ redis-cli -h localhost -p 8389 info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0

ubuntu@ip-172-31-8-82:~/go/src/GRS$ redis-cli  -p 8389 info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0

ubuntu@ip-172-31-4-135:~/go/src/GRS$ redis-cli -h ec2-52-11-1-193.us-west-2.compute.amazonaws.com -p 8389 info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0
```

3. UT test:
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ cd resource-management/pkg/store/redis/
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestSetGettString
--- PASS: TestSetGettString (0.00s)
=== RUN   TestPersistNodes
--- PASS: TestPersistNodes (0.00s)
=== RUN   TestPersistNodeStoreStatus
--- PASS: TestPersistNodeStoreStatus (0.00s)
=== RUN   TestPersistVirtualNodesAssignments
--- PASS: TestPersistVirtualNodesAssignments (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:234:
        First test is starting
    redis_test.go:278: Scan (2) logical nodes and actually get (2) logical nodes
    redis_test.go:281: Index #(0):
    redis_test.go:282: =================
    redis_test.go:283: Id:        (0003)
    redis_test.go:284: Region:    (1002)
    redis_test.go:285: RP:        (1002)
    redis_test.go:281: Index #(1):
    redis_test.go:282: =================
    redis_test.go:283: Id:        (0002)
    redis_test.go:284: Region:    (1001)
    redis_test.go:285: RP:        (1001)
    redis_test.go:287:
        First test is OK

    redis_test.go:290:
        Second test is starting
    redis_test.go:335: Scan (10) logical nodes and actually get (11) logical nodes
    redis_test.go:336:
        Second test is OK

    redis_test.go:339:
        Third test is starting
    redis_test.go:351: Scan (1000) logical nodes and actually get (1000) logical nodes
    redis_test.go:352:
        Third test is OK

    redis_test.go:355:
        Fourth test is starting
    redis_test.go:367: Scan (2000) logical nodes and actually get (2000) logical nodes
    redis_test.go:368:
        Fouth test is OK

    redis_test.go:371:
        The fifth test is starting
    redis_test.go:379: Scan (20000) logical nodes and actually get (10002) logical nodes
    redis_test.go:380:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (3.02s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     3.035s
```

4. Integration test:
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ kill -9 `ps -ef |grep service-api |grep -v grep |awk '{print $2}'`;kill -9 `ps -ef |grep service-api |grep -v grep |awk '{print $2}'`; go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-52-11-1-193.us-west-2.compute.amazonaws.com --resource_urls=ec2-54-187-22-27.us-west-2.compute.amazonaws.com:9119 --redis_port=8389 --enable_metrics=false -v=3  > ~/TMP/service.log.2022-09-20.v000183 2>&1 &

ubuntu@ip-172-31-8-205:~/go/src/GRS$ kill -9 `ps -ef |grep go |grep -v grep |awk {print $2}'`;kill -9 `ps -ef |grep go |grep -v grep |awk '{print $2}'`;go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Daily  -v=3  > ~/TMP/simulator1.log.2022-09-20.v000183 2>&1 &

ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ redis-cli -h ec2-52-11-1-193.us-west-2.compute.amazonaws.com -p 8389 info keyspace;date
# Keyspace
db0:keys=250001,expires=0,avg_ttl=0
Tue Sep 20 18:03:15 UTC 2022
```

Test2: use default port 7379
1. Installation test
```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ unset REDIS_NEW_PORT
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ echo $REDIS_NEW_PORT

ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ /bin/bash ~/go/src/GRS/hack/redis_install.sh
```

2. Local and remote connection test
```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ redis-cli -h ec2-52-11-1-193.us-west-2.compute.amazonaws.com -p 7379 info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0

ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ redis-cli -h ip-172-31-8-82 -p 7379 info keyspace                        
# Keyspace
db0:keys=1,expires=0,avg_ttl=0

ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ redis-cli -h localhost -p 7379 info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0

ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ redis-cli  -p 7379 info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0

Remote:
ubuntu@ip-172-31-4-135:~/go/src/GRS$ redis-cli -h ec2-52-11-1-193.us-west-2.compute.amazonaws.com -p 7379 info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0
```

3. UT test
```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestSetGettString
--- PASS: TestSetGettString (0.00s)
=== RUN   TestPersistNodes
--- PASS: TestPersistNodes (0.00s)
=== RUN   TestPersistNodeStoreStatus
--- PASS: TestPersistNodeStoreStatus (0.00s)
=== RUN   TestPersistVirtualNodesAssignments
--- PASS: TestPersistVirtualNodesAssignments (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:234:
        First test is starting
    redis_test.go:278: Scan (2) logical nodes and actually get (2) logical nodes
    redis_test.go:281: Index #(0):
    redis_test.go:282: =================
    redis_test.go:283: Id:        (0003)
    redis_test.go:284: Region:    (1002)
    redis_test.go:285: RP:        (1002)
    redis_test.go:281: Index #(1):
    redis_test.go:282: =================
    redis_test.go:283: Id:        (0002)
    redis_test.go:284: Region:    (1001)
    redis_test.go:285: RP:        (1001)
    redis_test.go:287:
        First test is OK

    redis_test.go:290:
        Second test is starting
    redis_test.go:335: Scan (10) logical nodes and actually get (10) logical nodes
    redis_test.go:336:
        Second test is OK

    redis_test.go:339:
        Third test is starting
    redis_test.go:351: Scan (1000) logical nodes and actually get (1000) logical nodes
    redis_test.go:352:
        Third test is OK

    redis_test.go:355:
        Fourth test is starting
    redis_test.go:367: Scan (2000) logical nodes and actually get (2000) logical nodes
    redis_test.go:368:
        Fouth test is OK

    redis_test.go:371:
        The fifth test is starting
    redis_test.go:379: Scan (20000) logical nodes and actually get (10002) logical nodes
    redis_test.go:380:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (2.96s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     2.980s
```

4. Integration test
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ kill -9 `ps -ef |grep service-api |grep -v grep |awk '{print $2}'`;kill -9 `ps -ef |grep service-api |grep -v grep |awk '{print $2}'`; go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-52-11-1-193.us-west-2.compute.amazonaws.com --resource_urls=ec2-54-187-22-27.us-west-2.compute.amazonaws.com:9119 --redis_port=7379 --enable_metrics=false -v=3  > ~/TMP/service.log.2022-09-20.v000184 2>&1 &

ubuntu@ip-172-31-8-205:~/go/src/GRS$ kill -9 `ps -ef |grep go |grep -v grep |awk {print $2}'`;kill -9 `ps -ef |grep go |grep -v grep |awk '{print $2}'`;go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Daily  -v=3  > ~/TMP/simulator1.log.2022-09-20.v000184 2>&1 &

ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ redis-cli -h ip-172-31-8-82 -p 7379 info keyspace;date
# Keyspace
db0:keys=250001,expires=0,avg_ttl=0
Tue Sep 20 17:55:49 UTC 2022

```

Successful Integration Test (500K nodes/2 regions/20 schedulers in us-west-2 + singleNodeInquiry from machine in remote region us-east-2) for SingleNodeInqury after second commit is posted

--- GRS service in us-west-2
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ kill -9 `ps -ef |grep service-api |grep -v grep |awk '{print $2}'`;kill -9 `ps -ef |grep service-api |grep -v grep |awk '{print $2}'`; go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-52-11-1-193.us-west-2.compute.amazonaws.com --resource_urls=ec2-54-187-22-27.us-west-2.compute.amazonaws.com:9119,ec2-35-91-52-72.us-west-2.compute.amazonaws.com:9119 --redis_port=8389 --enable_metrics=false -v=3  > ~/TMP/service.log.2022-09-22.v000184 2>&1 &
```

-- 2 region simulators in us-west-2
```
ubuntu@ip-172-31-8-205:~/go/src/GRS$ kill -9 `ps -ef |grep go |grep -v grep |awk {print $2}'`;kill -9 `ps -ef |grep go |grep -v grep |awk '{print $2}'`;go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Daily  -v=3  > ~/TMP/simulator1.log.2022-09-22.v000184 2>&1 &
ubuntu@ip-172-31-7-9:~/go/src/GRS$ kill -9 `ps -ef |grep go |grep -v grep |awk '{print $2}'`;kill -9 `ps -ef |grep go |grep -v grep |awk '{print $2}'`; go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Shanghai --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Daily -v=3 > ~/TMP/simulator2.log.2022-09-20.v000184 2>&1 &
```

-- 20 scheduler clients on 2 machines in us-west-2
```
ubuntu@ip-172-31-4-135:~/go/src/GRS$ for i in {1..10}; do sleep 1;   go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-52-11-1-193.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 --request_timeout=30m -v=3 > ~/TMP/scheduler.6.$i.log.2022-09-22.v000184 2>&1 & done
ubuntu@ip-172-31-1-189:~/go/src/GRS$ for i in {1..10}; do sleep 1;   go run resource-management/test/e2e/singleClientTest.go --service_url=ec2-52-11-1-193.us-west-2.compute.amazonaws.com:8080 --request_machines=25000 --action=watch --repeats=1 --limit=26000 --request_timeout=30m -v=3 > ~/TMP/scheduler.8.$i.log.2022-09-22.v000184 2>&1 & done
```

--- redis store on same machine of GRS in us-west-2
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ redis-cli -h ec2-52-11-1-193.us-west-2.compute.amazonaws.com -p 8389 info keyspace;date
# Keyspace
db0:keys=500021,expires=0,avg_ttl=0
Fri Sep 23 00:06:57 UTC 2022
```

---singleNodeInquiry from machine in us-east-2
```
ubuntu@ip-172-31-23-203:~/go/src/GRS$ go run test/e2e/singleNodeQuery.go -v=3 --service_url=ec2-52-11-1-193.us-west-2.compute.amazonaws.com:8080 --single_node_num=100 --batch_node_num=100 --remote_redis_port=8389 > ~/TMP/nodeuery.log.2022-09-22.v000184 2>&1 &
```
```
I0923 01:09:56.794232  196615 stats.go:39] [Metrics][Nodes]QueryInterval: 1s, Number of nodes queried during each interval: 1, perc50: 48.800672ms, perc90: 48.962408ms, perc99: 49.536601ms.
I0923 01:09:56.794634  196615 stats.go:39] [Metrics][Nodes]QueryInterval: 1m0s, Number of nodes queried during each interval: 100, perc50: 111.418732ms, perc90: 126.248211ms, perc99: 130.527159ms.

```

Also, the codes with branch simulator-list-watch have been tested in AWS integration test environment (5 million nodes/5 regions x 40 RPs x 25K nodes/100 scheduler clients x 25K nodes) successfully.
