### PR TITLE
change delay to 90s to get all vms ready in test-setup

### DIFF
--- a/hack/test-setup.sh
+++ b/hack/test-setup.sh
@@ -352,8 +352,8 @@ if [ "${ENABLE_ADMIN_E2E}" == "true" ]; then
 fi
 
  
-echo "Waiting 60 seconds to get all resource started"
-sleep 60
+echo "Waiting 90 seconds to get all resource started"
+sleep 90
 
 RESOURCE_URLS=""
 MASTER_IP=""


### PR DESCRIPTION
Issue found during testing, instance group need more times to get instance ready, change delay times from 60s to 90s.