### PR TITLE
Merge PR167 and PR171 about Redis changes into simulator-list-watch branch

### DIFF
--- a/hack/redis_install.sh
+++ b/hack/redis_install.sh
@@ -37,6 +37,11 @@
 #
 export PATH=$PATH
 
+REDIS_DEFAULT_PORT=${REDIS_DEFAULT_PORT:-6379}
+REDIS_NEW_PORT=${REDIS_NEW_PORT:-7379}
+REDIS_CONF_UBUNTU=${REDIS_CONF_UBUNTU:-"/etc/redis/redis.conf"}
+
+
 if [ `uname -s` == "Linux" ]; then
   LINUX_OS=`uname -v |awk -F'-' '{print $2}' |awk '{print $1}'`
 
@@ -79,29 +84,31 @@ if [ `uname -s` == "Linux" ]; then
     echo ""
     echo "2. Enable and Run Redis ......"
     echo "==============================="
-    REDIS_CONF_Ubuntu=/etc/redis/redis.conf
-    sudo ls -alg $REDIS_CONF_Ubuntu
+    sudo ls -alg $REDIS_CONF_UBUNTU
 
-    sudo sed -i -e "s/^supervised auto$/supervised systemd/g" $REDIS_CONF_Ubuntu
-    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |grep "supervised "
+    sudo sed -i -e "s/^supervised auto$/supervised systemd/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |grep "supervised "
 
-    sudo sed -i -e "s/^appendonly no$/appendonly yes/g" $REDIS_CONF_Ubuntu
-    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(appendonly |appendfsync )"
-
+    sudo sed -i -e "s/^appendonly no$/appendonly yes/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |egrep "(appendonly |appendfsync )"
+    
     # === Enable Redis server remote support
-    sudo sed -i -e "s/^bind 127.0.0.1 -::1$/bind 0.0.0.0/g" $REDIS_CONF_Ubuntu
-    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(bind 0.0.0.0)"
+    sudo sed -i -e "s/^bind 127.0.0.1 -::1$/bind 0.0.0.0/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |egrep "(bind 0.0.0.0)"
 
-    sudo sed -i -e "s/^protected-mode yes$/protected-mode no/g" $REDIS_CONF_Ubuntu
-    sudo egrep -v "(^#|^$)" $REDIS_CONF_Ubuntu |egrep "(protected-mode no)"
+    sudo sed -i -e "s/^protected-mode yes$/protected-mode no/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |egrep "(protected-mode no)"
+
+    sudo sed -i -e "s/^port $REDIS_DEFAULT_PORT$/port $REDIS_NEW_PORT/g" $REDIS_CONF_UBUNTU
+    sudo egrep -v "(^#|^$)" $REDIS_CONF_UBUNTU |egrep "(port $REDIS_NEW_PORT)"
     # === Enable Redis server remote support
 
     #
-    # Note: do not forget to open redis port 6379 in AWS Ubuntu OS level or GCE level
+    # Note: do not forget to open redis port 7379 in AWS Ubuntu OS level or GCE level
     #
-    # For example: Open port 6379 with ufw on AWS 
+    # For example: Open port 7379 with ufw on AWS 
     # $ sudo ufw status
-    # $ sudo ufw allow 6379/tcp
+    # $ sudo ufw allow 7379/tcp
     # $ sudo ufw status
     #
     # if ufw status is inactive, please enable ufw
@@ -115,8 +122,8 @@ if [ `uname -s` == "Linux" ]; then
     sudo systemctl restart redis-server.service
     sudo systemctl status redis-server.service
 
-    # Check whether network port 6379 is listened
-    sudo netstat -nlpt | grep 6379
+    # Check whether network port 7379 is listened
+    sudo netstat -nlpt | grep $REDIS_NEW_PORT
   else
     echo ""
     echo "This Linux OS ($LinuxOS) is currently not supported and exit"
@@ -185,19 +192,20 @@ echo ""
 echo "3. Simply Test Redis ......"
 echo "==============================="
 which redis-cli
+
 echo "3.1) Test ping ......"
-redis-cli ping 
+redis-cli -p $REDIS_NEW_PORT ping 
 
 echo ""
 echo "3.2) Test write key and value ......"
-redis-cli << EOF
+redis-cli -p $REDIS_NEW_PORT << EOF
 SET server:name "fido"
 GET server:name
 EOF
 
 echo ""
 echo "3.3) Test write queue ......"
-redis-cli << EOF
+redis-cli -p $REDIS_NEW_PORT << EOF
 lpush demos redis-macOS-demo
 rpop demos
 EOF

--- a/resource-management/cmds/service-api/app/server.go
+++ b/resource-management/cmds/service-api/app/server.go
@@ -38,14 +38,16 @@ type Config struct {
 	ResourceUrls              []string
 	MasterIp                  string
 	MasterPort                string
+	RedisPort		  string
 	EventMetricsDumpFrequency time.Duration
 }
 
 // Run and create new service-api.  This should never exit.
 func Run(c *Config) error {
 	klog.V(3).Infof("Starting the API server...")
+	klog.V(3).Infof("Connecting the Redis server via port (%v)...", c.RedisPort)
 
-	store := redis.NewRedisClient(c.MasterIp, true)
+	store := redis.NewRedisClient(c.MasterIp, c.RedisPort, false)
 	dist := distributor.GetResourceDistributor()
 	dist.SetPersistHelper(store)
 	installer := endpoints.NewInstaller(dist)

--- a/resource-management/cmds/service-api/service-api.go
+++ b/resource-management/cmds/service-api/service-api.go
@@ -40,6 +40,7 @@ func main() {
 	flag.StringVar(&c.MasterIp, "master_ip", "localhost", "Service IP address, if not set, default to localhost")
 	flag.StringVar(&c.MasterPort, "master_port", "8080", "Service port, if not set, default to 8080")
 	flag.StringVar(&urls, "resource_urls", "", "Resource urls of the resource manager services in each region")
+	flag.StringVar(&c.RedisPort, "redis_port", "7379", "Redis port, if not set, default to 7379")
 	flag.DurationVar(&c.EventMetricsDumpFrequency, "metrics_dump_frequency", 5*time.Minute, "Frequency to dump the event metrics, default 5m")
 	flag.BoolVar(&metricsEnabled, "enable_metrics", true, "Flag for if node event trace is enabled. default is enabled")
 
@@ -92,7 +93,7 @@ func printUsage() {
 	// klog will use commandline log parameters with nil as named a few below:
 	// --alsologtostderr=true  --logtostderr=false --log_file="/tmp/grs.log"
 	fmt.Println("logging options: --alsologtostderr=true  --logtostderr=false --log_file=/tmp/grs.log")
-	fmt.Println("service config options: --master_ip=<master address>  --master_port=<port> --resource_urls=<url1,url2,...>")
+	fmt.Println("service config options: --master_ip=<master address>  --master_port=<port> --redis_port=<port> --resource_urls=<url1,url2,...>")
 	fmt.Println("Explanation: <master address> could be public ip address or public dns name of the server")
 	fmt.Println("Gate flags: --enable_metrics=true  to enable the detailed event trace checkpoints")
 	os.Exit(0)

--- a/resource-management/pkg/store/redis/redis.go
+++ b/resource-management/pkg/store/redis/redis.go
@@ -36,12 +36,8 @@ type Goredis struct {
 	ctx    context.Context
 }
 
-const (
-	redisPort = "6379"
-)
-
 // Initialize Redis Client
-func NewRedisClient(redisServerIP string, flushAllFlag bool) *Goredis {
+func NewRedisClient(redisServerIP string, redisPort string, flushAllFlag bool) *Goredis {
 	redisAddress := fmt.Sprintf("%s:%s", redisServerIP, redisPort)
 
 	client := redis.NewClient(&redis.Options{

--- a/resource-management/pkg/store/redis/redis_test.go
+++ b/resource-management/pkg/store/redis/redis_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package redis
 
 import (
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -29,15 +30,27 @@ import (
 )
 
 var GR, GRInquiry *Goredis
+var redisPort string
+
+func setRedisPort() string {
+	if os.Getenv("REDIS_NEW_PORT") == "" {
+		redisPort = "7379"
+	} else {
+		redisPort = os.Getenv("REDIS_NEW_PORT")
+	}
+
+	return redisPort
+}
 
 func init() {
-	GR = NewRedisClient("localhost", true)
-	GRInquiry = NewRedisClient("localhost", false)
+	redisPort = setRedisPort()
+	GR = NewRedisClient("localhost", redisPort, true)
+	GRInquiry = NewRedisClient("localhost", redisPort, false)
 }
 
 func TestNewRedisClient(t *testing.T) {
-	GR = NewRedisClient("localhost", true)
-	GRInquiry = NewRedisClient("localhost", false)
+	GR = NewRedisClient("localhost", redisPort, true)
+	GRInquiry = NewRedisClient("localhost", redisPort, false)
 }
 
 // Simply Test Set String and Get String without the need of Marshal and Unmarshal
@@ -209,7 +222,7 @@ func TestPersistVirtualNodesAssignments(t *testing.T) {
 //
 func TestBatchLogicalNodeInquiry(t *testing.T) {
 	// Clean redis store to avoid test mess up due to previous tests
-	GR = NewRedisClient("localhost", true)
+	GR = NewRedisClient("localhost", redisPort, true)
 
 	// Start first test
 	t.Log("\nFirst test is starting")

--- a/test/e2e/singleNodeQuery.go
+++ b/test/e2e/singleNodeQuery.go
@@ -39,6 +39,7 @@ type testConfig struct {
 	singleNodeNum      int
 	singleNodeInterval time.Duration
 	batchNodeNum       int
+	remoteRedisPort    string
 	batchNodeInterval  time.Duration
 }
 
@@ -54,6 +55,7 @@ func main() {
 	flag.IntVar(&testCfg.singleNodeNum, "single_node_num", 1, "Number of single node set requested from redis, default to 1")
 	flag.DurationVar(&testCfg.singleNodeInterval, "single_node_interval", 1*time.Second, "Query interval of single node, default to 1s")
 	flag.IntVar(&testCfg.batchNodeNum, "batch_node_num", 10, "Number of batch node, default to 0s")
+	flag.StringVar(&testCfg.remoteRedisPort, "remote_redis_port", "7379", "Remote redis port, if not set, default to 7379")
 	flag.DurationVar(&testCfg.batchNodeInterval, "batch_node_interval", 1*time.Minute, "Query interval of batch node, default to 1m")
 
 	if !flag.Parsed() {
@@ -88,14 +90,16 @@ func main() {
 	}
 
 	// get multi nodes from redis for single node model and batch node model
-	redisIp := serviceInfo[0]
-	store := redis.NewRedisClient(redisIp, false)
+	remoteRedisIp := serviceInfo[0]
+	remoteRedisPort := testCfg.remoteRedisPort
+	klog.V(3).Infof("Connecting the Redis server at %v:%v", remoteRedisIp, remoteRedisPort)
+	store := redis.NewRedisClient(remoteRedisIp, remoteRedisPort, false)
 	requiredNum := testCfg.batchNodeNum + testCfg.singleNodeNum
 	startTime := time.Now().UTC()
 	klog.Infof("Requesting nodes from redis server")
 	logicalNodes := store.BatchLogicalNodesInquiry(requiredNum)
 	endTime := time.Since(startTime)
-	klog.Infof("Total %v nodes required from redis server: %v, Total nodes got from redis: %v in duration: %v, detailes: %v\n", requiredNum, redisIp, len(logicalNodes), endTime, logicalNodes)
+	klog.Infof("Total %v nodes required from redis server: %v, Total nodes got from redis: %v in duration: %v, detailes: %v\n", requiredNum, remoteRedisIp, len(logicalNodes), endTime, logicalNodes)
 
 	//split nodes from redis to singleNodeSet and batchNodeSet
 	singleNodeSet := make([]*types.LogicalNode, testCfg.singleNodeNum)
@@ -159,7 +163,7 @@ func main() {
 // function to print the usage info for the node query testing
 func printUsage() {
 	fmt.Println("Usage: ")
-	fmt.Println("--service_ip=127.0.0.1 --service_port=8080 --batch_node_num=100")
+	fmt.Println("--service_ip=127.0.0.1 --service_port=8080 --batch_node_num=100 --remote_redis_port=<port>")
 
 	os.Exit(0)
 }


### PR DESCRIPTION
This PR is same as PR179 which has been approved, only difference is the codes are pushed from personal branch q131172019/GRS:Carl_Merge_PR167_and_PR171_Into_simulator-list-watch.

This PR is to merge PR167 and PR171 into simulator-list-watch branch to be convenient for integration test

PR167 - Should not flushall redis DB when service API starts
PR171 - Change Redis default port 6379 to new port flexibly

UT test:
```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ go test -v
=== RUN   TestNewRedisClient
--- PASS: TestNewRedisClient (0.00s)
=== RUN   TestSetGettString
--- PASS: TestSetGettString (0.00s)
=== RUN   TestPersistNodes
--- PASS: TestPersistNodes (0.00s)
=== RUN   TestPersistNodeStoreStatus
--- PASS: TestPersistNodeStoreStatus (0.00s)
=== RUN   TestPersistVirtualNodesAssignments
--- PASS: TestPersistVirtualNodesAssignments (0.00s)
=== RUN   TestBatchLogicalNodeInquiry
    redis_test.go:219:
        First test is starting
    redis_test.go:263: Scan (2) logical nodes and actually get (2) logical nodes
    redis_test.go:266: Index #(0):
    redis_test.go:267: =================
    redis_test.go:268: Id:        (0002)
    redis_test.go:269: Region:    (1001)
    redis_test.go:270: RP:        (1001)
    redis_test.go:266: Index #(1):
    redis_test.go:267: =================
    redis_test.go:268: Id:        (0003)
    redis_test.go:269: Region:    (1002)
    redis_test.go:270: RP:        (1002)
    redis_test.go:272:
        First test is OK

    redis_test.go:275:
        Second test is starting
    redis_test.go:320: Scan (10) logical nodes and actually get (10) logical nodes
    redis_test.go:321:
        Second test is OK

    redis_test.go:324:
        Third test is starting
    redis_test.go:336: Scan (1000) logical nodes and actually get (1001) logical nodes
    redis_test.go:337:
        Third test is OK

    redis_test.go:340:
        Fourth test is starting
    redis_test.go:352: Scan (2000) logical nodes and actually get (2000) logical nodes
    redis_test.go:353:
        Fouth test is OK

    redis_test.go:356:
        The fifth test is starting
    redis_test.go:364: Scan (20000) logical nodes and actually get (10002) logical nodes
    redis_test.go:365:
        Fifth test is OK

--- PASS: TestBatchLogicalNodeInquiry (3.02s)
PASS
ok      global-resource-service/resource-management/pkg/store/redis     3.048s
```

The integration test have been done successfully in AWS environment (1 service-api and 1 region simulator)

-- service api
```
ubuntu@ip-172-31-8-82:~/go/src/GRS$ kill -9 `ps -ef |grep service-api |grep -v grep |awk '{print $2}'`;kill -9 `ps -ef |grep service-api |grep -v grep |awk '{print $2}'`; go run resource-management/cmds/service-api/service-api.go --master_ip=ec2-52-11-1-193.us-west-2.compute.amazonaws.com --resource_urls=ec2-54-187-22-27.us-west-2.compute.amazonaws.com:9119 --redis_port=7379 --enable_metrics=false -v=3  > ~/TMP/service.log.2022-09-19.v000182 2>&1 &
```

--- 1 simulator
```
ubuntu@ip-172-31-8-205:~/go/src/GRS$ kill -9 `ps -ef |grep go |grep -v grep |awk {print $2}'`;kill -9 `ps -ef |grep go |grep -v grep |awk '{print $2}'`;go run resource-management/test/resourceRegionMgrSimulator/main.go --region_name=Beijing --rp_num=10 --nodes_per_rp=25000 --master_port=9119 --data_pattern=Daily  -v=3  > ~/TMP/simulator1.log.2022-09-19.v000182 2>&1 &
```

--- redis-store
```
ubuntu@ip-172-31-8-82:~/go/src/GRS/resource-management/pkg/store/redis$ redis-cli -h ip-172-31-8-82 -p 7379 info keyspace
# Keyspace
db0:keys=250001,expires=0,avg_ttl=0

```